### PR TITLE
Added few more flags with information about pod.

### DIFF
--- a/hack/verify-flags/exceptions.txt
+++ b/hack/verify-flags/exceptions.txt
@@ -1,6 +1,8 @@
-dnsmasq-metrics/test/e2e/docker-run-e2e.sh:  --probe "notpresent,127.0.0.1:$((dnsmasq_port + 1)),notpresent.local,1" \
-mungegithub/mungers/submit-queue.go:		sq.e2e = &fake_e2e.FakeE2ETester{
-mungegithub/mungers/submit-queue.go:	fake_e2e "k8s.io/contrib/mungegithub/mungers/e2e/fake"
-mungegithub/mungers/submit-queue_test.go:	e2e := sq.e2e.(*fake_e2e.FakeE2ETester)
-mungegithub/mungers/submit-queue_test.go:	fake_e2e "k8s.io/contrib/mungegithub/mungers/e2e/fake"
-mungegithub/mungers/submit-queue_test.go:	sq.e2e = &fake_e2e.FakeE2ETester{
+kubelet-to-gcm/monitor/controller/translator.go:		"namespace_id":   "",
+kubelet-to-gcm/monitor/controller/translator.go:		"pod_id":         "machine",
+kubelet-to-gcm/monitor/kubelet/translate.go:				"namespace_id":   namespace,
+kubelet-to-gcm/monitor/kubelet/translate.go:				"pod_id":         podID,
+kubelet-to-gcm/monitor/kubelet/translate.go:		"namespace_id":   "",
+kubelet-to-gcm/monitor/kubelet/translate.go:		"pod_id":         "machine",
+prometheus-to-sd/translator/translator.go:		"namespace_id":   config.PodConfig.NamespaceId,
+prometheus-to-sd/translator/translator.go:		"pod_id":         config.PodConfig.PodId,

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -90,6 +90,7 @@ metric-descriptors-resolution
 metrics-resolution
 min-pr-number
 min-replica-count
+namespace-id
 netrc-dir
 network-config
 nginx-configmap
@@ -100,6 +101,7 @@ on-change
 one-time
 on-start
 path-label-config
+pod-id
 pod-scheduled-timeout
 poll-period
 presubmit-jobs

--- a/prometheus-to-sd/config/pod_config.go
+++ b/prometheus-to-sd/config/pod_config.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+// PodConfig describes pod in which current component is running.
+type PodConfig struct {
+	PodId       string
+	NamespaceId string
+}
+
+// CommonConfig contains all required information about environment in which
+// prometheus-to-sd running and which component is monitored.
+type CommonConfig struct {
+	GceConfig     *GceConfig
+	PodConfig     *PodConfig
+	ComponentName string
+}

--- a/prometheus-to-sd/config/source_config_test.go
+++ b/prometheus-to-sd/config/source_config_test.go
@@ -106,7 +106,7 @@ func TestParseSourceConfig(t *testing.T) {
 	}
 
 	for _, c := range incorrect {
-		res, err = ParseSourceConfig(c)
+		_, err = ParseSourceConfig(c)
 		assert.Error(t, err)
 	}
 }

--- a/prometheus-to-sd/main.go
+++ b/prometheus-to-sd/main.go
@@ -51,6 +51,10 @@ var (
 	apioverride = flag.String("api-override", "",
 		"The stackdriver API endpoint to override the default one used (which is prod).")
 	source = flags.Uris{}
+	podId  = flag.String("pod-id", "machine",
+		"Name of the pod in which monitored component is running.")
+	namespaceId = flag.String("namespace-id", "",
+		"Namespace name of the pod in which monitored component is running.")
 
 	customMetricsPrefix = "custom.googleapis.com"
 )
@@ -65,6 +69,10 @@ func main() {
 	sourceConfigs := extractSourceConfigsFromFlags()
 
 	gceConf, err := config.GetGceConfig(*metricsPrefix)
+	podConfig := &config.PodConfig{
+		PodId:       *podId,
+		NamespaceId: *namespaceId,
+	}
 	if err != nil {
 		glog.Fatalf("Failed to get GCE config: %v", err)
 	}
@@ -88,7 +96,7 @@ func main() {
 		glog.V(4).Infof("Starting goroutine for %+v", sourceConfig)
 
 		// Pass sourceConfig as a parameter to avoid using the last sourceConfig by all goroutines.
-		go readAndPushDataToStackdriver(stackdriverService, gceConf, sourceConfig)
+		go readAndPushDataToStackdriver(stackdriverService, gceConf, podConfig, sourceConfig)
 	}
 
 	// As worker goroutines work forever, block main thread as well.
@@ -119,7 +127,7 @@ func extractSourceConfigsFromFlags() []config.SourceConfig {
 	return sourceConfigs
 }
 
-func readAndPushDataToStackdriver(stackdriverService *v3.Service, gceConf *config.GceConfig, sourceConfig config.SourceConfig) {
+func readAndPushDataToStackdriver(stackdriverService *v3.Service, gceConf *config.GceConfig, podConfig *config.PodConfig, sourceConfig config.SourceConfig) {
 	glog.Infof("Running prometheus-to-sd, monitored target is %s %v:%v", sourceConfig.Component, sourceConfig.Host, sourceConfig.Port)
 
 	signal := time.After(0)
@@ -147,14 +155,19 @@ func readAndPushDataToStackdriver(stackdriverService *v3.Service, gceConf *confi
 		}
 
 		metrics, err := translator.GetPrometheusMetrics(sourceConfig.Host, sourceConfig.Port)
+		commonConfig := &config.CommonConfig{
+			GceConfig:     gceConf,
+			PodConfig:     podConfig,
+			ComponentName: sourceConfig.Component,
+		}
 		if err != nil {
 			glog.Warningf("Error while getting Prometheus metrics %v", err)
 			continue
 		}
 		if metricDescriptors != nil {
-			updateMetricDescriptorsDescription(stackdriverService, gceConf, metricDescriptors, metrics)
+			updateMetricDescriptorsDescription(stackdriverService, commonConfig, metricDescriptors, metrics)
 		}
-		ts := translator.TranslatePrometheusToStackdriver(gceConf, sourceConfig.Component, metrics, sourceConfig.Whitelisted)
+		ts := translator.TranslatePrometheusToStackdriver(commonConfig, metrics, sourceConfig.Whitelisted)
 		translator.SendToStackdriver(stackdriverService, gceConf, ts)
 	}
 }
@@ -167,13 +180,13 @@ func updateWhitelistedMetrics(sourceConfig *config.SourceConfig, metricDescripto
 }
 
 func updateMetricDescriptorsDescription(stackdriverService *v3.Service,
-	config *config.GceConfig,
+	config *config.CommonConfig,
 	descriptors map[string]*v3.MetricDescriptor,
 	metrics map[string]*dto.MetricFamily) {
 	for _, metricFamily := range metrics {
 		metricDescriptor, ok := descriptors[metricFamily.GetName()]
 		if (!ok || metricDescriptor.Description != metricFamily.GetHelp()) && strings.HasPrefix(metricDescriptor.Type, customMetricsPrefix) {
-			updatedMetricDescriptor := translator.MetricFamilyToMetricDescriptor(config, *component, metricFamily)
+			updatedMetricDescriptor := translator.MetricFamilyToMetricDescriptor(config, metricFamily)
 			translator.CreateMetricDescriptor(stackdriverService, config, updatedMetricDescriptor)
 		}
 	}

--- a/prometheus-to-sd/translator/stackdriver.go
+++ b/prometheus-to-sd/translator/stackdriver.go
@@ -100,8 +100,8 @@ func GetMetricDescriptors(service *v3.Service, config *config.GceConfig, compone
 }
 
 // CreateMetricDescriptor creates or updates existing MetricDescriptor.
-func CreateMetricDescriptor(service *v3.Service, config *config.GceConfig, metricDescriptor *v3.MetricDescriptor) {
-	projectName := createProjectName(config)
+func CreateMetricDescriptor(service *v3.Service, config *config.CommonConfig, metricDescriptor *v3.MetricDescriptor) {
+	projectName := createProjectName(config.GceConfig)
 	_, err := service.Projects.MetricDescriptors.Create(projectName, metricDescriptor).Do()
 	if err != nil {
 		glog.Errorf("Error in attempt to update metric descriptor %v", err)

--- a/prometheus-to-sd/translator/stackdriver_test.go
+++ b/prometheus-to-sd/translator/stackdriver_test.go
@@ -25,9 +25,12 @@ import (
 )
 
 func TestGetMetricType(t *testing.T) {
-	testConfig := &config.GceConfig{MetricsPrefix: "container.googleapis.com/master"}
+	testConfig := &config.CommonConfig{
+		GceConfig:     &config.GceConfig{MetricsPrefix: "container.googleapis.com/master"},
+		ComponentName: "component",
+	}
 	expected := "container.googleapis.com/master/component/name"
-	assert.Equal(t, expected, getMetricType(testConfig, "component", "name"))
+	assert.Equal(t, expected, getMetricType(testConfig, "name"))
 }
 
 func TestParseMetricType(t *testing.T) {

--- a/prometheus-to-sd/translator/translator.go
+++ b/prometheus-to-sd/translator/translator.go
@@ -33,8 +33,33 @@ const (
 	processStartTimeMetric = "process_start_time_seconds"
 )
 
+var supportedMetricTypes = map[dto.MetricType]bool{
+	dto.MetricType_COUNTER:   true,
+	dto.MetricType_GAUGE:     true,
+	dto.MetricType_HISTOGRAM: true,
+}
+
 // TranslatePrometheusToStackdriver translates metrics in Prometheus format to Stackdriver format.
-func TranslatePrometheusToStackdriver(config *config.GceConfig, component string, metrics map[string]*dto.MetricFamily, whitelisted []string) []*v3.TimeSeries {
+func TranslatePrometheusToStackdriver(config *config.CommonConfig,
+	metrics map[string]*dto.MetricFamily,
+	whitelisted []string) []*v3.TimeSeries {
+
+	startTime := getStartTime(metrics)
+	metrics = filterWhitelisted(metrics, whitelisted)
+
+	var ts []*v3.TimeSeries
+	for name, metric := range metrics {
+		t, err := translateFamily(config, metric, startTime)
+		if err != nil {
+			glog.Warningf("Error while processing metric %s: %v", name, err)
+		} else {
+			ts = append(ts, t...)
+		}
+	}
+	return ts
+}
+
+func getStartTime(metrics map[string]*dto.MetricFamily) time.Time {
 	// For cumulative metrics we need to know process start time.
 	// If the process start time is not specified, assuming it's
 	// the unix 1 second, because Stackdriver can't handle
@@ -47,25 +72,13 @@ func TranslatePrometheusToStackdriver(config *config.GceConfig, component string
 	} else {
 		glog.Warningf("Metric %s invalid or not defined. Using %v instead. Cumulative metrics might be inaccurate.", processStartTimeMetric, startTime)
 	}
-	endTime := time.Now()
-
-	if len(whitelisted) > 0 {
-		metrics = filterWhitelisted(metrics, whitelisted)
-	}
-
-	var ts []*v3.TimeSeries
-	for name, metric := range metrics {
-		t, err := translateFamily(config, component, metric, startTime, endTime)
-		if err != nil {
-			glog.Warningf("Error while processing metric %s: %v", name, err)
-		} else {
-			ts = append(ts, t...)
-		}
-	}
-	return ts
+	return startTime
 }
 
 func filterWhitelisted(allMetrics map[string]*dto.MetricFamily, whitelisted []string) map[string]*dto.MetricFamily {
+	if len(whitelisted) == 0 {
+		return allMetrics
+	}
 	glog.V(4).Infof("Exporting only whitelisted metrics: %v", whitelisted)
 	res := map[string]*dto.MetricFamily{}
 	for _, w := range whitelisted {
@@ -78,14 +91,14 @@ func filterWhitelisted(allMetrics map[string]*dto.MetricFamily, whitelisted []st
 	return res
 }
 
-func translateFamily(config *config.GceConfig, component string, family *dto.MetricFamily, start, end time.Time) ([]*v3.TimeSeries, error) {
+func translateFamily(config *config.CommonConfig, family *dto.MetricFamily, startTime time.Time) ([]*v3.TimeSeries, error) {
 	glog.V(4).Infof("Translating metric family %v", family.GetName())
 	var ts []*v3.TimeSeries
-	if family.GetType() != dto.MetricType_COUNTER && family.GetType() != dto.MetricType_GAUGE && family.GetType() != dto.MetricType_HISTOGRAM {
+	if _, found := supportedMetricTypes[family.GetType()]; !found {
 		return ts, fmt.Errorf("Metric type %v of family %s not supported", family.GetType(), family.GetName())
 	}
 	for _, metric := range family.GetMetric() {
-		t := translateOne(config, component, family.GetName(), family.GetType(), metric, start, end)
+		t := translateOne(config, family.GetName(), family.GetType(), metric, startTime)
 		ts = append(ts, t)
 		glog.V(4).Infof("%+v\nMetric: %+v, Interval: %+v", *t, *(t.Metric), t.Points[0].Interval)
 	}
@@ -93,14 +106,14 @@ func translateFamily(config *config.GceConfig, component string, family *dto.Met
 }
 
 // getMetricType creates metric type name base on the metric prefix, component name and metric name.
-func getMetricType(config *config.GceConfig, component string, name string) string {
-	return fmt.Sprintf("%s/%s/%s", config.MetricsPrefix, component, name)
+func getMetricType(config *config.CommonConfig, name string) string {
+	return fmt.Sprintf("%s/%s/%s", config.GceConfig.MetricsPrefix, config.ComponentName, name)
 }
 
 // assumes that mType is Counter, Gauge or Histogram
-func translateOne(config *config.GceConfig, component string, name string, mType dto.MetricType, metric *dto.Metric, start, end time.Time) *v3.TimeSeries {
+func translateOne(config *config.CommonConfig, name string, mType dto.MetricType, metric *dto.Metric, start time.Time) *v3.TimeSeries {
 	interval := &v3.TimeInterval{
-		EndTime: end.UTC().Format(time.RFC3339),
+		EndTime: time.Now().UTC().Format(time.RFC3339),
 	}
 	metricKind := extractMetricKind(mType)
 	if metricKind == "CUMULATIVE" {
@@ -118,7 +131,7 @@ func translateOne(config *config.GceConfig, component string, name string, mType
 	return &v3.TimeSeries{
 		Metric: &v3.Metric{
 			Labels: getMetricLabels(metric.GetLabel()),
-			Type:   getMetricType(config, component, name),
+			Type:   getMetricType(config, name),
 		},
 		Resource: &v3.MonitoredResource{
 			Labels: getResourceLabels(config),
@@ -136,7 +149,7 @@ func setValue(mType dto.MetricType, metric *dto.Metric, point *v3.Point) {
 		point.Value.Int64Value = &val
 		point.ForceSendFields = append(point.ForceSendFields, "Int64Value")
 	} else if mType == dto.MetricType_HISTOGRAM {
-		point.Value.DistributionValue = getHistogramValue(metric.GetHistogram())
+		point.Value.DistributionValue = convertToDistributionValue(metric.GetHistogram())
 		point.ForceSendFields = append(point.ForceSendFields, "DistributionValue")
 	} else {
 		val := int64(metric.GetCounter().GetValue())
@@ -145,7 +158,7 @@ func setValue(mType dto.MetricType, metric *dto.Metric, point *v3.Point) {
 	}
 }
 
-func getHistogramValue(h *dto.Histogram) *v3.Distribution {
+func convertToDistributionValue(h *dto.Histogram) *v3.Distribution {
 	count := int64(h.GetSampleCount())
 	mean := float64(0)
 	dev := float64(0)
@@ -197,10 +210,10 @@ func getMetricLabels(labels []*dto.LabelPair) map[string]string {
 }
 
 // MetricFamilyToMetricDescriptor converts MetricFamily object to the MetricDescriptor.
-func MetricFamilyToMetricDescriptor(config *config.GceConfig, component string, family *dto.MetricFamily) *v3.MetricDescriptor {
+func MetricFamilyToMetricDescriptor(config *config.CommonConfig, family *dto.MetricFamily) *v3.MetricDescriptor {
 	return &v3.MetricDescriptor{
 		Description: family.GetHelp(),
-		Type:        getMetricType(config, component, family.GetName()),
+		Type:        getMetricType(config, family.GetName()),
 		MetricKind:  extractMetricKind(family.GetType()),
 		ValueType:   extractValueType(family.GetType()),
 		Labels:      extractAllLabels(family),
@@ -240,14 +253,14 @@ func createProjectName(config *config.GceConfig) string {
 	return fmt.Sprintf("projects/%s", config.Project)
 }
 
-func getResourceLabels(config *config.GceConfig) map[string]string {
+func getResourceLabels(config *config.CommonConfig) map[string]string {
 	return map[string]string{
-		"project_id":     config.Project,
-		"cluster_name":   config.Cluster,
-		"zone":           config.Zone,
-		"instance_id":    config.Instance,
-		"namespace_id":   "",
-		"pod_id":         "machine",
+		"project_id":     config.GceConfig.Project,
+		"cluster_name":   config.GceConfig.Cluster,
+		"zone":           config.GceConfig.Zone,
+		"instance_id":    config.GceConfig.Instance,
+		"namespace_id":   config.PodConfig.NamespaceId,
+		"pod_id":         config.PodConfig.PodId,
 		"container_name": "",
 	}
 }

--- a/prometheus-to-sd/translator/translator_test.go
+++ b/prometheus-to-sd/translator/translator_test.go
@@ -42,15 +42,20 @@ func (ts ByMetricTypeReversed) Less(i, j int) bool {
 	return ts[i].Metric.Type > ts[j].Metric.Type
 }
 
-var gceConfig = &config.GceConfig{
-	Project:       "test-proj",
-	Zone:          "us-central1-f",
-	Cluster:       "test-cluster",
-	Instance:      "kubernetes-master.c.test-proj.internal",
-	MetricsPrefix: "container.googleapis.com/master",
+var commonConfig = &config.CommonConfig{
+	GceConfig: &config.GceConfig{
+		Project:       "test-proj",
+		Zone:          "us-central1-f",
+		Cluster:       "test-cluster",
+		Instance:      "kubernetes-master.c.test-proj.internal",
+		MetricsPrefix: "container.googleapis.com/master",
+	},
+	PodConfig: &config.PodConfig{
+		NamespaceId: "",
+		PodId:       "machine",
+	},
+	ComponentName: "testcomponent",
 }
-
-var component = "testcomponent"
 
 var metricTypeGauge = dto.MetricType_GAUGE
 var metricTypeCounter = dto.MetricType_COUNTER
@@ -171,7 +176,7 @@ var metricDescriptors = map[string]*v3.MetricDescriptor{
 func TestTranslatePrometheusToStackdriver(t *testing.T) {
 	epsilon := float64(0.001)
 
-	ts := TranslatePrometheusToStackdriver(gceConfig, component, metrics, []string{testMetricName, testMetricHistogram})
+	ts := TranslatePrometheusToStackdriver(commonConfig, metrics, []string{testMetricName, testMetricHistogram})
 
 	assert.Equal(t, 3, len(ts))
 	// TranslatePrometheusToStackdriver uses maps to represent data, so order of output is randomized.
@@ -230,7 +235,7 @@ func TestTranslatePrometheusToStackdriver(t *testing.T) {
 
 func TestMetricFamilyToMetricDescriptor(t *testing.T) {
 	for metricName, metric := range metrics {
-		metricDescriptor := MetricFamilyToMetricDescriptor(gceConfig, component, metric)
+		metricDescriptor := MetricFamilyToMetricDescriptor(commonConfig, metric)
 		expectedMetricDescriptor := metricDescriptors[metricName]
 		assert.Equal(t, metricDescriptor, expectedMetricDescriptor)
 	}


### PR DESCRIPTION
Add flag pod-id and namespace-id that are used to create correct
monitored resource object for the stackdriver.

Additionally some small refactoring to improve readability.

This PR is base on https://github.com/kubernetes/contrib/pull/2649,
which was already merged in the contrib repository.