### PR TITLE
Update labels of metric descriptors if they change

### DIFF
--- a/prometheus-to-sd/config/source_config.go
+++ b/prometheus-to-sd/config/source_config.go
@@ -22,6 +22,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/golang/glog"
+
 	"github.com/GoogleCloudPlatform/k8s-stackdriver/prometheus-to-sd/flags"
 )
 
@@ -33,8 +35,8 @@ type SourceConfig struct {
 	Whitelisted []string
 }
 
-// NewSourceConfig creates a new SourceConfig based on string representation of fields.
-func NewSourceConfig(component string, host string, port string, whitelisted string) (*SourceConfig, error) {
+// newSourceConfig creates a new SourceConfig based on string representation of fields.
+func newSourceConfig(component string, host string, port string, whitelisted string) (*SourceConfig, error) {
 	if port == "" {
 		return nil, fmt.Errorf("No port provided.")
 	}
@@ -57,8 +59,8 @@ func NewSourceConfig(component string, host string, port string, whitelisted str
 	}, nil
 }
 
-// ParseSourceConfig creates a new SourceConfig based on the provided flags.Uri instance.
-func ParseSourceConfig(uri flags.Uri) (*SourceConfig, error) {
+// parseSourceConfig creates a new SourceConfig based on the provided flags.Uri instance.
+func parseSourceConfig(uri flags.Uri) (*SourceConfig, error) {
 	host, port, err := net.SplitHostPort(uri.Val.Host)
 	if err != nil {
 		return nil, err
@@ -68,5 +70,35 @@ func ParseSourceConfig(uri flags.Uri) (*SourceConfig, error) {
 	values := uri.Val.Query()
 	whitelisted := values.Get("whitelisted")
 
-	return NewSourceConfig(component, host, port, whitelisted)
+	return newSourceConfig(component, host, port, whitelisted)
+}
+
+// UpdateWhitelistedMetrics sets passed list as a list of whitelisted metrics.
+func (config *SourceConfig) UpdateWhitelistedMetrics(list []string) {
+	config.Whitelisted = list
+}
+
+// SourceConfigsFromFlags creates a slice of SourceConfig's base on the provided flags.
+func SourceConfigsFromFlags(source flags.Uris, component *string, host *string, port *uint, whitelisted *string) []SourceConfig {
+	var sourceConfigs []SourceConfig
+	for _, c := range source {
+		if sourceConfig, err := parseSourceConfig(c); err != nil {
+			glog.Fatalf("Error while parsing source config flag %v: %v", c, err)
+		} else {
+			sourceConfigs = append(sourceConfigs, *sourceConfig)
+		}
+	}
+
+	if len(source) == 0 && *component != "" {
+		glog.Warningf("--component, --host, --port and --whitelisted flags are deprecated. Please use --source instead.")
+		portStr := strconv.FormatUint(uint64(*port), 10)
+
+		if sourceConfig, err := newSourceConfig(*component, *host, portStr, *whitelisted); err != nil {
+			glog.Fatalf("Error while parsing --component flag: %v", err)
+		} else {
+			glog.Infof("Created a new source instance from --component flag: %+v", sourceConfig)
+			sourceConfigs = append(sourceConfigs, *sourceConfig)
+		}
+	}
+	return sourceConfigs
 }

--- a/prometheus-to-sd/config/source_config_test.go
+++ b/prometheus-to-sd/config/source_config_test.go
@@ -53,7 +53,7 @@ func TestNewSourceConfig(t *testing.T) {
 	}
 
 	for _, c := range correct {
-		res, err := NewSourceConfig(c.component, c.host, c.port, c.whitelisted)
+		res, err := newSourceConfig(c.component, c.host, c.port, c.whitelisted)
 		if assert.NoError(t, err) {
 			assert.Equal(t, c.output, *res)
 		}
@@ -81,7 +81,7 @@ func TestParseSourceConfig(t *testing.T) {
 		},
 	}
 
-	res, err := ParseSourceConfig(correct.in)
+	res, err := parseSourceConfig(correct.in)
 	if assert.NoError(t, err) {
 		assert.Equal(t, correct.output, *res)
 	}
@@ -106,7 +106,7 @@ func TestParseSourceConfig(t *testing.T) {
 	}
 
 	for _, c := range incorrect {
-		_, err = ParseSourceConfig(c)
+		_, err = parseSourceConfig(c)
 		assert.Error(t, err)
 	}
 }

--- a/prometheus-to-sd/main.go
+++ b/prometheus-to-sd/main.go
@@ -18,12 +18,9 @@ package main
 
 import (
 	"flag"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/golang/glog"
-	dto "github.com/prometheus/client_model/go"
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
@@ -32,6 +29,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-stackdriver/prometheus-to-sd/config"
 	"github.com/GoogleCloudPlatform/k8s-stackdriver/prometheus-to-sd/flags"
 	"github.com/GoogleCloudPlatform/k8s-stackdriver/prometheus-to-sd/translator"
+	"strings"
 )
 
 var (
@@ -66,7 +64,7 @@ func main() {
 	defer glog.Flush()
 	flag.Parse()
 
-	sourceConfigs := extractSourceConfigsFromFlags()
+	sourceConfigs := config.SourceConfigsFromFlags(source, component, host, port, whitelisted)
 
 	gceConf, err := config.GetGceConfig(*metricsPrefix)
 	podConfig := &config.PodConfig{
@@ -103,48 +101,28 @@ func main() {
 	<-make(chan int)
 }
 
-func extractSourceConfigsFromFlags() []config.SourceConfig {
-	var sourceConfigs []config.SourceConfig
-	for _, c := range source {
-		if sourceConfig, err := config.ParseSourceConfig(c); err != nil {
-			glog.Fatalf("Error while parsing source config flag %v: %v", c, err)
-		} else {
-			sourceConfigs = append(sourceConfigs, *sourceConfig)
-		}
-	}
-
-	if len(source) == 0 && *component != "" {
-		glog.Warningf("--component, --host, --port and --whitelisted flags are deprecated. Please use --source instead.")
-		portStr := strconv.FormatUint(uint64(*port), 10)
-
-		if sourceConfig, err := config.NewSourceConfig(*component, *host, portStr, *whitelisted); err != nil {
-			glog.Fatalf("Error while parsing --component flag: %v", err)
-		} else {
-			glog.Infof("Created a new source instance from --component flag: %+v", sourceConfig)
-			sourceConfigs = append(sourceConfigs, *sourceConfig)
-		}
-	}
-	return sourceConfigs
-}
-
 func readAndPushDataToStackdriver(stackdriverService *v3.Service, gceConf *config.GceConfig, podConfig *config.PodConfig, sourceConfig config.SourceConfig) {
 	glog.Infof("Running prometheus-to-sd, monitored target is %s %v:%v", sourceConfig.Component, sourceConfig.Host, sourceConfig.Port)
-
+	commonConfig := &config.CommonConfig{
+		GceConfig:     gceConf,
+		PodConfig:     podConfig,
+		ComponentName: sourceConfig.Component,
+	}
+	metricDescriptorCache := translator.NewMetricDescriptorCache(stackdriverService, commonConfig, sourceConfig.Component)
 	signal := time.After(0)
 	useWhitelistedMetricsAutodiscovery := *autoWhitelistMetrics && len(sourceConfig.Whitelisted) == 0
 
 	for range time.Tick(*resolution) {
+		// Mark cache at the beginning of each iteration as stale. Cache is considered refreshed only if during
+		// current iteration there was successful call to Refresh function.
+		metricDescriptorCache.MarkStale()
 		glog.V(4).Infof("Scraping metrics of component %v", sourceConfig.Component)
-		var metricDescriptors map[string]*v3.MetricDescriptor
 		select {
 		case <-signal:
 			glog.V(4).Infof("Updating metrics cache for component %v", sourceConfig.Component)
-			var err error
-			if metricDescriptors, err = translator.GetMetricDescriptors(stackdriverService, gceConf, sourceConfig.Component); err != nil {
-				glog.Warningf("Error while fetching metric descriptors for %v: %v", sourceConfig.Component, err)
-			}
+			metricDescriptorCache.Refresh()
 			if useWhitelistedMetricsAutodiscovery {
-				updateWhitelistedMetrics(&sourceConfig, metricDescriptors)
+				sourceConfig.UpdateWhitelistedMetrics(metricDescriptorCache.GetMetricNames())
 			}
 			signal = time.After(*metricDescriptorsResolution)
 		default:
@@ -153,41 +131,15 @@ func readAndPushDataToStackdriver(stackdriverService *v3.Service, gceConf *confi
 			glog.V(4).Infof("Skipping %v component as there are no metric to expose.", sourceConfig.Component)
 			continue
 		}
-
 		metrics, err := translator.GetPrometheusMetrics(sourceConfig.Host, sourceConfig.Port)
-		commonConfig := &config.CommonConfig{
-			GceConfig:     gceConf,
-			PodConfig:     podConfig,
-			ComponentName: sourceConfig.Component,
-		}
 		if err != nil {
 			glog.Warningf("Error while getting Prometheus metrics %v", err)
 			continue
 		}
-		if metricDescriptors != nil {
-			updateMetricDescriptorsDescription(stackdriverService, commonConfig, metricDescriptors, metrics)
+		if strings.HasPrefix(commonConfig.GceConfig.MetricsPrefix, customMetricsPrefix) {
+			metricDescriptorCache.UpdateMetricDescriptors(metrics, sourceConfig.Whitelisted)
 		}
-		ts := translator.TranslatePrometheusToStackdriver(commonConfig, metrics, sourceConfig.Whitelisted)
+		ts := translator.TranslatePrometheusToStackdriver(commonConfig, sourceConfig.Whitelisted, metrics, metricDescriptorCache)
 		translator.SendToStackdriver(stackdriverService, gceConf, ts)
-	}
-}
-
-func updateWhitelistedMetrics(sourceConfig *config.SourceConfig, metricDescriptors map[string]*v3.MetricDescriptor) {
-	sourceConfig.Whitelisted = nil
-	for metricName := range metricDescriptors {
-		sourceConfig.Whitelisted = append(sourceConfig.Whitelisted, metricName)
-	}
-}
-
-func updateMetricDescriptorsDescription(stackdriverService *v3.Service,
-	config *config.CommonConfig,
-	descriptors map[string]*v3.MetricDescriptor,
-	metrics map[string]*dto.MetricFamily) {
-	for _, metricFamily := range metrics {
-		metricDescriptor, ok := descriptors[metricFamily.GetName()]
-		if (!ok || metricDescriptor.Description != metricFamily.GetHelp()) && strings.HasPrefix(metricDescriptor.Type, customMetricsPrefix) {
-			updatedMetricDescriptor := translator.MetricFamilyToMetricDescriptor(config, metricFamily)
-			translator.CreateMetricDescriptor(stackdriverService, config, updatedMetricDescriptor)
-		}
 	}
 }

--- a/prometheus-to-sd/translator/metric_descriptor_cache.go
+++ b/prometheus-to-sd/translator/metric_descriptor_cache.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package translator
+
+import (
+	"github.com/golang/glog"
+	dto "github.com/prometheus/client_model/go"
+	v3 "google.golang.org/api/monitoring/v3"
+
+	"github.com/GoogleCloudPlatform/k8s-stackdriver/prometheus-to-sd/config"
+)
+
+// MetricDescriptorCache is responsible for fetching, creating and updating metric descriptors from the stackdriver.
+type MetricDescriptorCache struct {
+	descriptors map[string]*v3.MetricDescriptor
+	broken      map[string]bool
+	service     *v3.Service
+	config      *config.CommonConfig
+	component   string
+	fresh       bool
+}
+
+// NewMetricDescriptorCache creates empty metric descriptor cache for the given component.
+func NewMetricDescriptorCache(service *v3.Service, config *config.CommonConfig, component string) *MetricDescriptorCache {
+	return &MetricDescriptorCache{
+		descriptors: make(map[string]*v3.MetricDescriptor),
+		broken:      make(map[string]bool),
+		service:     service,
+		config:      config,
+		component:   component,
+		fresh:       false,
+	}
+}
+
+// IsMetricBroken returns true if this metric descriptor assumed to invalid (for examples it has too many labels).
+func (cache *MetricDescriptorCache) IsMetricBroken(name string) bool {
+	broken, ok := cache.broken[name]
+	return ok && broken
+}
+
+// GetMetricNames returns a list of all metric names from the cache.
+func (cache *MetricDescriptorCache) GetMetricNames() []string {
+	keys := make([]string, 0, len(cache.descriptors))
+	for k := range cache.descriptors {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// MarkStale marks all records in the cache as stale until next Refresh() call.
+func (cache *MetricDescriptorCache) MarkStale() {
+	cache.fresh = false
+}
+
+// UpdateMetricDescriptors iterates over all metricFamilies and updates metricDescriptors in the Stackdriver if required.
+func (cache *MetricDescriptorCache) UpdateMetricDescriptors(metrics map[string]*dto.MetricFamily, whitelisted []string) {
+	// Perform cache operation only if cache was recently refreshed. This is done mostly from the optimization point
+	// of view, we don't want to check all metric descriptors too often, as they should change rarely.
+	if !cache.fresh {
+		return
+	}
+	for _, metricFamily := range metrics {
+		if isMetricWhitelisted(metricFamily.GetName(), whitelisted) {
+			cache.updateMetricDescriptorIfStale(metricFamily)
+		}
+	}
+}
+
+func isMetricWhitelisted(metric string, whitelisted []string) bool {
+	// Empty list means that we want to fetch all metrics.
+	if len(whitelisted) == 0 {
+		return true
+	}
+	for _, whitelistedMetric := range whitelisted {
+		if whitelistedMetric == metric {
+			return true
+		}
+	}
+	return false
+}
+
+// updateMetricDescriptorIfStale checks if descriptor created from MetricFamily object differs from the existing one
+// and updates if needed.
+func (cache *MetricDescriptorCache) updateMetricDescriptorIfStale(metricFamily *dto.MetricFamily) {
+	metricDescriptor, ok := cache.descriptors[metricFamily.GetName()]
+	updatedMetricDescriptor := MetricFamilyToMetricDescriptor(cache.config, metricFamily, metricDescriptor)
+	if !ok || descriptorChanged(metricDescriptor, updatedMetricDescriptor) {
+		if updateMetricDescriptorInStackdriver(cache.service, cache.config.GceConfig, updatedMetricDescriptor) {
+			cache.descriptors[metricFamily.GetName()] = updatedMetricDescriptor
+		} else {
+			cache.broken[metricFamily.GetName()] = true
+		}
+	}
+}
+
+func descriptorChanged(original *v3.MetricDescriptor, checked *v3.MetricDescriptor) bool {
+	if original.Description != checked.Description {
+		glog.V(4).Infof("Description is different, %v != %v", original.Description, checked.Description)
+		return true
+	}
+	for _, label := range checked.Labels {
+		found := false
+		for _, labelFromOriginal := range original.Labels {
+			if label.Key == labelFromOriginal.Key {
+				found = true
+				break
+			}
+		}
+		if !found {
+			glog.V(4).Infof("Missing label %v in the original metric descriptor", label)
+			return true
+		}
+	}
+	return false
+}
+
+// Refresh function fetches all metric descriptors of all metrics defined for given component with a defined prefix
+// and puts them into cache.
+func (cache *MetricDescriptorCache) Refresh() {
+	metricDescriptors, err := getMetricDescriptors(cache.service, cache.config.GceConfig, cache.component)
+	if err == nil {
+		cache.descriptors = metricDescriptors
+		cache.broken = make(map[string]bool)
+		cache.fresh = true
+	}
+}

--- a/prometheus-to-sd/translator/metric_descriptor_cache_test.go
+++ b/prometheus-to-sd/translator/metric_descriptor_cache_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package translator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v3 "google.golang.org/api/monitoring/v3"
+)
+
+var equalDescriptor = "equal"
+var differentDescription = "differentDescription"
+var differentLabels = "differentLabels"
+
+var description1 = "Simple description"
+var description2 = "Complex description"
+
+var label1 = &v3.LabelDescriptor{Key: "label1"}
+var label2 = &v3.LabelDescriptor{Key: "label2"}
+var label3 = &v3.LabelDescriptor{Key: "label3"}
+
+var originalDescriptor = v3.MetricDescriptor{
+	Name:        equalDescriptor,
+	Description: description1,
+	Labels:      []*v3.LabelDescriptor{label1, label2},
+}
+
+var otherDescriptors = map[*v3.MetricDescriptor]bool{
+	{
+		Name:        equalDescriptor,
+		Description: description1,
+		Labels:      []*v3.LabelDescriptor{label1, label2},
+	}: false,
+	{
+		Name:        differentDescription,
+		Description: description2,
+		Labels:      []*v3.LabelDescriptor{label1, label2},
+	}: true,
+	{
+		Name:        differentLabels,
+		Description: description1,
+		Labels:      []*v3.LabelDescriptor{label3},
+	}: true,
+}
+
+func TestDescriptorChanged(t *testing.T) {
+	for descriptor, result := range otherDescriptors {
+		if result {
+			assert.True(t, descriptorChanged(&originalDescriptor, descriptor))
+		} else {
+			assert.False(t, descriptorChanged(&originalDescriptor, descriptor))
+		}
+	}
+}

--- a/prometheus-to-sd/translator/translator.go
+++ b/prometheus-to-sd/translator/translator.go
@@ -41,14 +41,18 @@ var supportedMetricTypes = map[dto.MetricType]bool{
 
 // TranslatePrometheusToStackdriver translates metrics in Prometheus format to Stackdriver format.
 func TranslatePrometheusToStackdriver(config *config.CommonConfig,
+	whitelisted []string,
 	metrics map[string]*dto.MetricFamily,
-	whitelisted []string) []*v3.TimeSeries {
+	cache *MetricDescriptorCache) []*v3.TimeSeries {
 
 	startTime := getStartTime(metrics)
 	metrics = filterWhitelisted(metrics, whitelisted)
 
 	var ts []*v3.TimeSeries
 	for name, metric := range metrics {
+		if cache.IsMetricBroken(name) {
+			continue
+		}
 		t, err := translateFamily(config, metric, startTime)
 		if err != nil {
 			glog.Warningf("Error while processing metric %s: %v", name, err)
@@ -209,14 +213,16 @@ func getMetricLabels(labels []*dto.LabelPair) map[string]string {
 	return metricLabels
 }
 
-// MetricFamilyToMetricDescriptor converts MetricFamily object to the MetricDescriptor.
-func MetricFamilyToMetricDescriptor(config *config.CommonConfig, family *dto.MetricFamily) *v3.MetricDescriptor {
+// MetricFamilyToMetricDescriptor converts MetricFamily object to the MetricDescriptor. If needed it uses information
+// from the previously created metricDescriptor (for example to merge label sets).
+func MetricFamilyToMetricDescriptor(config *config.CommonConfig,
+	family *dto.MetricFamily, originalDescriptor *v3.MetricDescriptor) *v3.MetricDescriptor {
 	return &v3.MetricDescriptor{
 		Description: family.GetHelp(),
 		Type:        getMetricType(config, family.GetName()),
 		MetricKind:  extractMetricKind(family.GetType()),
 		ValueType:   extractValueType(family.GetType()),
-		Labels:      extractAllLabels(family),
+		Labels:      extractAllLabels(family, originalDescriptor),
 	}
 }
 
@@ -234,7 +240,7 @@ func extractValueType(mType dto.MetricType) string {
 	return "INT64"
 }
 
-func extractAllLabels(family *dto.MetricFamily) []*v3.LabelDescriptor {
+func extractAllLabels(family *dto.MetricFamily, originalDescriptor *v3.MetricDescriptor) []*v3.LabelDescriptor {
 	var labels []*v3.LabelDescriptor
 	labelSet := make(map[string]bool)
 	for _, metric := range family.GetMetric() {
@@ -243,6 +249,15 @@ func extractAllLabels(family *dto.MetricFamily) []*v3.LabelDescriptor {
 			if !ok {
 				labels = append(labels, &v3.LabelDescriptor{Key: label.GetName()})
 				labelSet[label.GetName()] = true
+			}
+		}
+	}
+	if originalDescriptor != nil {
+		for _, label := range originalDescriptor.Labels {
+			_, ok := labelSet[label.Key]
+			if !ok {
+				labels = append(labels, label)
+				labelSet[label.Key] = true
 			}
 		}
 	}

--- a/prometheus-to-sd/translator/translator_test.go
+++ b/prometheus-to-sd/translator/translator_test.go
@@ -175,8 +175,9 @@ var metricDescriptors = map[string]*v3.MetricDescriptor{
 
 func TestTranslatePrometheusToStackdriver(t *testing.T) {
 	epsilon := float64(0.001)
+	cache := NewMetricDescriptorCache(nil, nil, commonConfig.ComponentName)
 
-	ts := TranslatePrometheusToStackdriver(commonConfig, metrics, []string{testMetricName, testMetricHistogram})
+	ts := TranslatePrometheusToStackdriver(commonConfig, []string{testMetricName, testMetricHistogram}, metrics, cache)
 
 	assert.Equal(t, 3, len(ts))
 	// TranslatePrometheusToStackdriver uses maps to represent data, so order of output is randomized.
@@ -235,7 +236,7 @@ func TestTranslatePrometheusToStackdriver(t *testing.T) {
 
 func TestMetricFamilyToMetricDescriptor(t *testing.T) {
 	for metricName, metric := range metrics {
-		metricDescriptor := MetricFamilyToMetricDescriptor(commonConfig, metric)
+		metricDescriptor := MetricFamilyToMetricDescriptor(commonConfig, metric, nil)
 		expectedMetricDescriptor := metricDescriptors[metricName]
 		assert.Equal(t, metricDescriptor, expectedMetricDescriptor)
 	}


### PR DESCRIPTION
This PR includes few minor changes that fixes issues in the prometheus-to-sd component:

1. Component is not trying to update metric descriptor if this metric was not whitelisted.
2. Updates metric descriptor if new label was added.
3. Don't send broken metrics to the stackdriver (for example when name is longer than 100 characters or number of labels bigger than 10)
4. If sending of batch of timeserieses to the Stackdriver fails, correct number of sent timeserieses is logged.