### PR TITLE
Introduce omit-component-name flag.

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -97,6 +97,7 @@ nginx-configmap
 nonblocking-jenkins-jobs
 number-of-old-test-results
 ok-total-unready-count
+omit-component-name
 on-change
 one-time
 on-start

--- a/prometheus-to-sd/main.go
+++ b/prometheus-to-sd/main.go
@@ -53,6 +53,8 @@ var (
 		"Name of the pod in which monitored component is running.")
 	namespaceId = flag.String("namespace-id", "",
 		"Namespace name of the pod in which monitored component is running.")
+	omitComponentName = flag.Bool("omit-component-name", true,
+		"If metric name starts with the component name then this substring is removed to keep metric name shorter.")
 
 	customMetricsPrefix = "custom.googleapis.com"
 )
@@ -135,6 +137,9 @@ func readAndPushDataToStackdriver(stackdriverService *v3.Service, gceConf *confi
 		if err != nil {
 			glog.Warningf("Error while getting Prometheus metrics %v", err)
 			continue
+		}
+		if *omitComponentName {
+			metrics = translator.OmitComponentName(metrics, sourceConfig.Component)
 		}
 		if strings.HasPrefix(commonConfig.GceConfig.MetricsPrefix, customMetricsPrefix) {
 			metricDescriptorCache.UpdateMetricDescriptors(metrics, sourceConfig.Whitelisted)

--- a/prometheus-to-sd/translator/translator.go
+++ b/prometheus-to-sd/translator/translator.go
@@ -19,6 +19,7 @@ package translator
 import (
 	"fmt"
 	"math"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -61,6 +62,17 @@ func TranslatePrometheusToStackdriver(config *config.CommonConfig,
 		}
 	}
 	return ts
+}
+
+// OmitComponentName removes from the metric names prefix that is equal to component name.
+func OmitComponentName(metricFamilies map[string]*dto.MetricFamily, componentName string) map[string]*dto.MetricFamily {
+	result := make(map[string]*dto.MetricFamily)
+	for metricName, metricFamily := range metricFamilies {
+		newMetricName := strings.TrimPrefix(metricName, fmt.Sprintf("%s_", componentName))
+		metricFamily.Name = &newMetricName
+		result[newMetricName] = metricFamily
+	}
+	return result
 }
 
 func getStartTime(metrics map[string]*dto.MetricFamily) time.Time {

--- a/prometheus-to-sd/translator/translator_test.go
+++ b/prometheus-to-sd/translator/translator_test.go
@@ -19,6 +19,7 @@ package translator
 import (
 	"math"
 	"sort"
+	"strings"
 	"testing"
 
 	dto "github.com/prometheus/client_model/go"
@@ -239,6 +240,33 @@ func TestMetricFamilyToMetricDescriptor(t *testing.T) {
 		metricDescriptor := MetricFamilyToMetricDescriptor(commonConfig, metric, nil)
 		expectedMetricDescriptor := metricDescriptors[metricName]
 		assert.Equal(t, metricDescriptor, expectedMetricDescriptor)
+	}
+}
+
+func TestOmitComponentName(t *testing.T) {
+	var normalMetric1 = "metric1"
+	var metricWithSomePrefix = "some_prefix_metric2"
+	var metricWithComponentPrefix = "testcomponent_metric"
+	var metricWithIncorrectComponentPrefix = "testcomponentmetric"
+
+	var metricFamiliesForWhitelistTest = map[string]*dto.MetricFamily{
+		normalMetric1: {
+			Name: stringPtr(normalMetric1),
+		},
+		metricWithSomePrefix: {
+			Name: stringPtr(metricWithSomePrefix),
+		},
+		metricWithComponentPrefix: {
+			Name: stringPtr(metricWithComponentPrefix),
+		},
+		metricWithIncorrectComponentPrefix: {
+			Name: stringPtr(metricWithIncorrectComponentPrefix),
+		},
+	}
+	processedMetrics := OmitComponentName(metricFamiliesForWhitelistTest, "testcomponent")
+	for k, v := range processedMetrics {
+		assert.False(t, strings.HasPrefix(k, "testcomponent_"))
+		assert.False(t, strings.HasPrefix(*v.Name, "testcomponent_"))
 	}
 }
 


### PR DESCRIPTION
If flag is set to true then component name is removed from metrics that
have such prefix. For example etcd_version_info is going to be
represented as container.googleapis.com/etcd/version_info.