### PR TITLE
Fix race in event-exporter tests

### DIFF
--- a/event-exporter/sinks/stackdriver/sink_test.go
+++ b/event-exporter/sinks/stackdriver/sink_test.go
@@ -63,6 +63,9 @@ func TestMaxConcurrency(t *testing.T) {
 		s.OnAdd(&api_v1.Event{})
 	}
 
+	wait.Poll(100*time.Millisecond, 1*time.Second, func() (bool, error) {
+		return len(q) == config.MaxConcurrency, nil
+	})
 	if len(q) != config.MaxConcurrency {
 		t.Fatalf("Write called %d times, expected %d", len(q), config.MaxConcurrency)
 	}


### PR DESCRIPTION
Since sink sends requests asynchronously, there's a delay between calling OnAdd method and calling Write method in another goroutine. There should have been a timeout until the latter method is actually called, without this timeout it was possible for the main goroutine to reach the check before second goroutine gets the chance to add enough object to the channel.

Fixes https://github.com/GoogleCloudPlatform/k8s-stackdriver/issues/12