### PR TITLE
Add support of double and boolean values.

### DIFF
--- a/prometheus-to-sd/translator/metric_descriptor_cache.go
+++ b/prometheus-to-sd/translator/metric_descriptor_cache.go
@@ -107,6 +107,14 @@ func (cache *MetricDescriptorCache) updateMetricDescriptorIfStale(metricFamily *
 	}
 }
 
+func (cache *MetricDescriptorCache) getMetricDescriptor(metric string) *v3.MetricDescriptor {
+	value, ok := cache.descriptors[metric]
+	if !ok {
+		glog.Warningf("Metric %s was not found in the cache.", metric)
+	}
+	return value
+}
+
 func descriptorChanged(original *v3.MetricDescriptor, checked *v3.MetricDescriptor) bool {
 	if original.Description != checked.Description {
 		glog.V(4).Infof("Description is different, %v != %v", original.Description, checked.Description)


### PR DESCRIPTION
If stored in the stackdriver MetricDescritor has type value DOUBLE or
BOOL, then convert value received from the prometheus to the correct
value before pushing it to the stackdriver.