### PR TITLE
Update version of prom-to-sd to 0.2.1.

### DIFF
--- a/prometheus-to-sd/Makefile
+++ b/prometheus-to-sd/Makefile
@@ -16,7 +16,7 @@ all: build
 
 ENVVAR = GOOS=linux GOARCH=amd64 CGO_ENABLED=0
 PREFIX = gcr.io/google-containers
-TAG = v0.2.0
+TAG = v0.2.1
 
 build:
 	$(ENVVAR) godep go build -a -o monitor


### PR DESCRIPTION
This version is able to handle double and bool values.
Pprof is added.