### PR TITLE
[event-exporter] Treat update with empty previous object as non-error

### DIFF
--- a/event-exporter/Makefile
+++ b/event-exporter/Makefile
@@ -19,7 +19,7 @@ BINARY_NAME = event-exporter
 
 PREFIX = gcr.io/google-containers
 IMAGE_NAME = event-exporter
-TAG = v0.1.4
+TAG = v0.1.5
 
 build:
 	${ENVVAR} godep go build -a -o ${BINARY_NAME}

--- a/event-exporter/sinks/stackdriver/sink.go
+++ b/event-exporter/sinks/stackdriver/sink.go
@@ -90,13 +90,19 @@ func (s *sdSink) OnAdd(event *api_v1.Event) {
 }
 
 func (s *sdSink) OnUpdate(oldEvent *api_v1.Event, newEvent *api_v1.Event) {
-	if newEvent.Count != oldEvent.Count+1 {
+	var oldCount int32
+	if oldEvent != nil {
+		oldCount = oldEvent.Count
+	}
+
+	if newEvent.Count != oldCount+1 {
 		// Sink doesn't send a LogEntry to Stackdriver, b/c event compression might
 		// indicate that part of the watch history was lost, which may result in
 		// multiple events being compressed. This may create an unecessary
-		// flood in Stackdriver.
+		// flood in Stackdriver. Also this is a perfectly valid behavior for the
+		// configuration with empty backing storage.
 		glog.V(2).Infof("Event count has increased by %d != 1.\n"+
-			"\tOld event: %+v\n\tNew event: %+v", newEvent.Count-oldEvent.Count, oldEvent, newEvent)
+			"\tOld event: %+v\n\tNew event: %+v", newEvent.Count-oldCount, oldEvent, newEvent)
 	}
 
 	receivedEntryCount.WithLabelValues(newEvent.Source.Component, newEvent.Source.Host).Inc()

--- a/event-exporter/watchers/events/handler.go
+++ b/event-exporter/watchers/events/handler.go
@@ -50,7 +50,7 @@ func (c *eventHandlerWrapper) OnAdd(obj interface{}) {
 func (c *eventHandlerWrapper) OnUpdate(oldObj interface{}, newObj interface{}) {
 	oldEvent, oldOk := c.convert(oldObj)
 	newEvent, newOk := c.convert(newObj)
-	if oldOk && newOk {
+	if newOk && (oldObj == nil || oldOk) {
 		c.handler.OnUpdate(oldEvent, newEvent)
 	}
 }

--- a/event-exporter/watchers/events/handler_test.go
+++ b/event-exporter/watchers/events/handler_test.go
@@ -97,7 +97,7 @@ func TestEventWatchHandlerUpdate(t *testing.T) {
 			"oldObj=nil,newObj=event",
 			nil,
 			&api_v1.Event{},
-			false,
+			true,
 		},
 		{
 			"oldObj=non-event,newObj=event",


### PR DESCRIPTION
Because it's a valid behavior for the situation with empty backing storage.