### PR TITLE
[event-exporter] Propagate location from the configuration parameters

### DIFF
--- a/event-exporter/Makefile
+++ b/event-exporter/Makefile
@@ -19,7 +19,7 @@ BINARY_NAME = event-exporter
 
 PREFIX = gcr.io/google-containers
 IMAGE_NAME = event-exporter
-TAG = v0.1.5
+TAG = v0.1.6
 
 build:
 	${ENVVAR} godep go build -a -o ${BINARY_NAME}
@@ -27,7 +27,7 @@ build:
 test:
 	${ENVVAR} godep go test ./...
 
-container: build
+container:
 	docker build --pull -t ${PREFIX}/${IMAGE_NAME}:${TAG} .
 
 push: container

--- a/event-exporter/sinks/stackdriver/sink_config.go
+++ b/event-exporter/sinks/stackdriver/sink_config.go
@@ -43,7 +43,7 @@ type sdSinkConfig struct {
 	Resource       *sd.MonitoredResource
 }
 
-func newGceSdSinkConfig() (*sdSinkConfig, error) {
+func newGceSdSinkConfig(location string) (*sdSinkConfig, error) {
 	if !metadata.OnGCE() {
 		return nil, errors.New("not running on GCE, which is not supported for Stackdriver sink")
 	}
@@ -65,9 +65,8 @@ func newGceSdSinkConfig() (*sdSinkConfig, error) {
 		Type: "gke_cluster",
 		Labels: map[string]string{
 			"cluster_name": clusterName,
-			// TODO: Replace with the actual zone of the cluster
-			"location":   "",
-			"project_id": projectID,
+			"location":     location,
+			"project_id":   projectID,
 		},
 	}
 

--- a/event-exporter/sinks/stackdriver/sink_factory.go
+++ b/event-exporter/sinks/stackdriver/sink_factory.go
@@ -35,6 +35,7 @@ type sdSinkFactory struct {
 	flushDelay     *time.Duration
 	maxBufferSize  *int
 	maxConcurrency *int
+	location       *string
 }
 
 // NewSdSinkFactory creates a new Stackdriver sink factory
@@ -49,6 +50,7 @@ func NewSdSinkFactory() sinks.SinkFactory {
 			"in the request to Stackdriver"),
 		maxConcurrency: fs.Int("max-concurrency", defaultMaxConcurrency, "Maximum number of "+
 			"concurrent requests to Stackdriver"),
+		location: fs.String("location", "", "GCE location of the cluster"),
 	}
 }
 
@@ -81,7 +83,7 @@ func (f *sdSinkFactory) CreateNew(opts []string) (sinks.Sink, error) {
 }
 
 func (f *sdSinkFactory) createSinkConfig() (*sdSinkConfig, error) {
-	config, err := newGceSdSinkConfig()
+	config, err := newGceSdSinkConfig(*f.location)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Makes it possible to specify a location in the event-exporter configuration, that will be used to associate the events with.

/cc @piosz 