### PR TITLE
Use prometheus to generate the http client

### DIFF
--- a/prometheus-to-sd/config/source_config.go
+++ b/prometheus-to-sd/config/source_config.go
@@ -59,7 +59,7 @@ func newSourceConfig(component string, host string, port string, whitelisted str
 
 	client := http.DefaultClient
 	if config != "" {
-		cfg, err := LoadHTTPConfigFile(config)
+		cfg, err := loadHTTPConfigFile(config)
 		if err != nil {
 			return nil, err
 		}
@@ -124,17 +124,17 @@ func SourceConfigsFromFlags(source flags.Uris, component *string, host *string, 
 	return sourceConfigs
 }
 
-// LoadHTTPConfigFile parses the given YAML file into a HTTPClientConfig.
-func LoadHTTPConfigFile(filename string) (*promconfig.HTTPClientConfig, error) {
+// loadHTTPConfigFile parses the given YAML file into a HTTPClientConfig.
+func loadHTTPConfigFile(filename string) (*promconfig.HTTPClientConfig, error) {
 	content, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
-	return LoadHTTPConfig(content)
+	return loadHTTPConfig(content)
 }
 
-// LoadHTTPConfig parses the YAML input s into a HTTPClientConfig.
-func LoadHTTPConfig(data []byte) (*promconfig.HTTPClientConfig, error) {
+// loadHTTPConfig parses the YAML inputs into a HTTPClientConfig.
+func loadHTTPConfig(data []byte) (*promconfig.HTTPClientConfig, error) {
 	cfg := &promconfig.HTTPClientConfig{}
 	err := yaml.Unmarshal(data, cfg)
 	if err != nil {

--- a/prometheus-to-sd/config/source_config_test.go
+++ b/prometheus-to-sd/config/source_config_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"net/http"
 	"net/url"
 	"testing"
 
@@ -31,29 +32,32 @@ func TestNewSourceConfig(t *testing.T) {
 		host        string
 		port        string
 		whitelisted string
+		config      string
 		output      SourceConfig
 	}{
-		{"testComponent", "localhost", "1234", "a,b,c,d",
+		{"testComponent", "localhost", "1234", "a,b,c,d", "",
 			SourceConfig{
 				Component:   "testComponent",
 				Host:        "localhost",
 				Port:        1234,
 				Whitelisted: []string{"a", "b", "c", "d"},
+				Client:      http.DefaultClient,
 			},
 		},
 
-		{"testComponent", "localhost", "1234", "",
+		{"testComponent", "localhost", "1234", "", "",
 			SourceConfig{
 				Component:   "testComponent",
 				Host:        "localhost",
 				Port:        1234,
 				Whitelisted: nil,
+				Client:      http.DefaultClient,
 			},
 		},
 	}
 
 	for _, c := range correct {
-		res, err := newSourceConfig(c.component, c.host, c.port, c.whitelisted)
+		res, err := newSourceConfig(c.component, c.host, c.port, c.whitelisted, c.config)
 		if assert.NoError(t, err) {
 			assert.Equal(t, c.output, *res)
 		}
@@ -78,6 +82,7 @@ func TestParseSourceConfig(t *testing.T) {
 			Host:        "hostname",
 			Port:        1234,
 			Whitelisted: []string{"a", "b", "c", "d"},
+			Client:      http.DefaultClient,
 		},
 	}
 

--- a/prometheus-to-sd/main.go
+++ b/prometheus-to-sd/main.go
@@ -142,7 +142,7 @@ func readAndPushDataToStackdriver(stackdriverService *v3.Service, gceConf *confi
 			glog.V(4).Infof("Skipping %v component as there are no metric to expose.", sourceConfig.Component)
 			continue
 		}
-		metrics, err := translator.GetPrometheusMetrics(sourceConfig.Host, sourceConfig.Port)
+		metrics, err := translator.GetPrometheusMetrics(sourceConfig.Host, sourceConfig.Port, sourceConfig.Client)
 		if err != nil {
 			glog.V(2).Infof("Error while getting Prometheus metrics %v for component %v", err, sourceConfig.Component)
 			continue

--- a/prometheus-to-sd/translator/prometheus.go
+++ b/prometheus-to-sd/translator/prometheus.go
@@ -27,9 +27,9 @@ import (
 )
 
 // GetPrometheusMetrics scrapes metrics from the given host and port using /metrics handler.
-func GetPrometheusMetrics(host string, port uint) (map[string]*dto.MetricFamily, error) {
+func GetPrometheusMetrics(host string, port uint, client *http.Client) (map[string]*dto.MetricFamily, error) {
 	url := fmt.Sprintf("http://%s:%d/metrics", host, port)
-	resp, err := http.Get(url)
+	resp, err := client.Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("request %s failed: %v", url, err)
 	}


### PR DESCRIPTION
Generate the client calling the `/metrics` endpoint using Prometheus' [config package](https://godoc.org/github.com/prometheus/common/config) to read standard Prometheus configuration options.

This enables various authentication methods when scraping protected metrics.

Closes #35.

**Wasn't sure how to update the vendored dependencies (never used godep).**