### PR TITLE
[event-exporter] Remove host from the metric labels

### DIFF
--- a/event-exporter/Makefile
+++ b/event-exporter/Makefile
@@ -19,7 +19,7 @@ BINARY_NAME = event-exporter
 
 PREFIX = gcr.io/google-containers
 IMAGE_NAME = event-exporter
-TAG = v0.1.6
+TAG = v0.1.7
 
 build:
 	${ENVVAR} godep go build -a -o ${BINARY_NAME}

--- a/event-exporter/sinks/stackdriver/sink.go
+++ b/event-exporter/sinks/stackdriver/sink.go
@@ -34,7 +34,7 @@ var (
 			Help:      "Number of entries, recieved by the Stackdriver sink",
 			Subsystem: "stackdriver_sink",
 		},
-		[]string{"component", "host"},
+		[]string{"component"},
 	)
 
 	successfullySentEntryCount = prometheus.NewCounter(
@@ -83,7 +83,7 @@ func newSdSink(writer sdWriter, clock clock.Clock, config *sdSinkConfig) *sdSink
 }
 
 func (s *sdSink) OnAdd(event *api_v1.Event) {
-	receivedEntryCount.WithLabelValues(event.Source.Component, event.Source.Host).Inc()
+	receivedEntryCount.WithLabelValues(event.Source.Component).Inc()
 
 	logEntry := s.logEntryFactory.FromEvent(event)
 	s.logEntryChannel <- logEntry
@@ -105,7 +105,7 @@ func (s *sdSink) OnUpdate(oldEvent *api_v1.Event, newEvent *api_v1.Event) {
 			"\tOld event: %+v\n\tNew event: %+v", newEvent.Count-oldCount, oldEvent, newEvent)
 	}
 
-	receivedEntryCount.WithLabelValues(newEvent.Source.Component, newEvent.Source.Host).Inc()
+	receivedEntryCount.WithLabelValues(newEvent.Source.Component).Inc()
 
 	logEntry := s.logEntryFactory.FromEvent(newEvent)
 	s.logEntryChannel <- logEntry


### PR DESCRIPTION
In the clusters with CA, the number of metric streams will continuously grow if the host is included.

@piosz 