### PR TITLE
prometheus-to-sd: support additional labels for source

### DIFF
--- a/prometheus-to-sd/config/source_config_test.go
+++ b/prometheus-to-sd/config/source_config_test.go
@@ -31,29 +31,35 @@ func TestNewSourceConfig(t *testing.T) {
 		host        string
 		port        string
 		whitelisted string
+		labels      string
 		output      SourceConfig
 	}{
-		{"testComponent", "localhost", "1234", "a,b,c,d",
+		{"testComponent", "localhost", "1234", "a,b,c,d", "keya=valuea,keyb=valueb",
 			SourceConfig{
 				Component:   "testComponent",
 				Host:        "localhost",
 				Port:        1234,
 				Whitelisted: []string{"a", "b", "c", "d"},
+				Labels: map[string]string{
+					"keya": "valuea",
+					"keyb": "valueb",
+				},
 			},
 		},
 
-		{"testComponent", "localhost", "1234", "",
+		{"testComponent", "localhost", "1234", "", "",
 			SourceConfig{
 				Component:   "testComponent",
 				Host:        "localhost",
 				Port:        1234,
 				Whitelisted: nil,
+				Labels:      map[string]string{},
 			},
 		},
 	}
 
 	for _, c := range correct {
-		res, err := newSourceConfig(c.component, c.host, c.port, c.whitelisted)
+		res, err := newSourceConfig(c.component, c.host, c.port, c.whitelisted, c.labels)
 		if assert.NoError(t, err) {
 			assert.Equal(t, c.output, *res)
 		}
@@ -70,7 +76,7 @@ func TestParseSourceConfig(t *testing.T) {
 			Val: url.URL{
 				Scheme:   "http",
 				Host:     "hostname:1234",
-				RawQuery: "whitelisted=a,b,c,d",
+				RawQuery: "whitelisted=a,b,c,d&labels=keya=valuea,keyb=valueb",
 			},
 		},
 		SourceConfig{
@@ -78,6 +84,10 @@ func TestParseSourceConfig(t *testing.T) {
 			Host:        "hostname",
 			Port:        1234,
 			Whitelisted: []string{"a", "b", "c", "d"},
+			Labels: map[string]string{
+				"keya": "valuea",
+				"keyb": "valueb",
+			},
 		},
 	}
 
@@ -101,6 +111,14 @@ func TestParseSourceConfig(t *testing.T) {
 				Scheme:   "http",
 				Host:     "hostname",
 				RawQuery: "whitelisted=a,b,c,d",
+			},
+		},
+		{
+			Key: "incorrectLabels",
+			Val: url.URL{
+				Scheme:   "http",
+				Host:     "hostname:1234",
+				RawQuery: "labels=keya,keyb",
 			},
 		},
 	}

--- a/prometheus-to-sd/main.go
+++ b/prometheus-to-sd/main.go
@@ -65,7 +65,7 @@ var (
 
 func main() {
 	flag.Set("logtostderr", "true")
-	flag.Var(&source, "source", "source(s) to watch in [component-name]:http://host:port?whitelisted=a,b,c format")
+	flag.Var(&source, "source", "source(s) to watch in [component-name]:http://host:port?whitelisted=a,b,c&labels=keya=valuea,keyb=valueb format")
 
 	defer glog.Flush()
 	flag.Parse()
@@ -154,6 +154,11 @@ func readAndPushDataToStackdriver(stackdriverService *v3.Service, gceConf *confi
 			metricDescriptorCache.UpdateMetricDescriptors(metrics, sourceConfig.Whitelisted)
 		}
 		ts := translator.TranslatePrometheusToStackdriver(commonConfig, sourceConfig.Whitelisted, metrics, metricDescriptorCache)
+		for i := range ts {
+			for k, v := range sourceConfig.Labels {
+				ts[i].Resource.Labels[k] = v
+			}
+		}
 		translator.SendToStackdriver(stackdriverService, commonConfig, ts)
 	}
 }


### PR DESCRIPTION
This CL is used to add custom labels to time series metrics scraped from pods.

Allowing custom labels makes aggregation more easy and useful on stackdriver.