### PR TITLE
Validate metric descriptors before pushing.

### DIFF
--- a/prometheus-to-sd/main.go
+++ b/prometheus-to-sd/main.go
@@ -152,6 +152,8 @@ func readAndPushDataToStackdriver(stackdriverService *v3.Service, gceConf *confi
 		}
 		if strings.HasPrefix(commonConfig.GceConfig.MetricsPrefix, customMetricsPrefix) {
 			metricDescriptorCache.UpdateMetricDescriptors(metrics, sourceConfig.Whitelisted)
+		} else {
+			metricDescriptorCache.ValidateMetricDescriptors(metrics, sourceConfig.Whitelisted)
 		}
 		ts := translator.TranslatePrometheusToStackdriver(commonConfig, sourceConfig.Whitelisted, metrics, metricDescriptorCache)
 		translator.SendToStackdriver(stackdriverService, commonConfig, ts)


### PR DESCRIPTION
Previously we have been missing check of correctness for metrics with
prefix "container.googleapis.com". As a result if metric has changed all
batch of timeserieses was failing. Now such metric is going to be
ignored and warning logged.