### PR TITLE
Don't set custom metrics reader permission in adapter deployment

### DIFF
--- a/custom-metrics-stackdriver-adapter/adapter-beta.yaml
+++ b/custom-metrics-stackdriver-adapter/adapter-beta.yaml
@@ -120,37 +120,4 @@ spec:
     name: custom-metrics-stackdriver-adapter
     namespace: custom-metrics
   version: v1beta1
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: custom-metrics-reader
-rules:
-- apiGroups:
-  - "custom.metrics.k8s.io"
-  resources:
-  - "*"
-  verbs:
-  - list
-  - get
-  - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: custom-metrics-reader
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: custom-metrics-reader
-subjects:
-- apiGroup: rbac.authorization.k8s.io
-  kind: Group
-  name: system:anonymous
-- apiGroup: rbac.authorization.k8s.io
-  kind: Group
-  name: system:unauthenticated
-- kind: ServiceAccount
-  name: horizontal-pod-autoscaler
-  namespace: kube-system
 


### PR DESCRIPTION
After PR: https://github.com/kubernetes/kubernetes/pull/54854 HPA can read custom metrics with default permissions.