### PR TITLE
Code for Prometheus Gauge to Stackdriver Cumulative translation logic

### DIFF
--- a/prometheus-to-sd/config/pod_config.go
+++ b/prometheus-to-sd/config/pod_config.go
@@ -28,4 +28,8 @@ type CommonConfig struct {
 	GceConfig     *GceConfig
 	PodConfig     *PodConfig
 	ComponentName string
+	// Contains metrics which will be converted from Prometheus
+	// Gauge to Stackdriver Cumulative. Temporary workaround
+	// which will be removed.
+	GaugeToCumulativeWhitelist []string
 }

--- a/prometheus-to-sd/main.go
+++ b/prometheus-to-sd/main.go
@@ -59,7 +59,9 @@ var (
 	omitComponentName = flag.Bool("omit-component-name", true,
 		"If metric name starts with the component name then this substring is removed to keep metric name shorter.")
 	debugPort = flag.Uint("port", 6061, "Port on which debug information is exposed.")
-
+	// Warning: Does not work for custom.googleapis.com endpoints.
+	gaugeToCumulativeWhitelist = flag.String("gauge-to-cumulative-whitelist", "",
+	        "Comma-separated list of Prometheus Gauge metrics which will be converted to Stackdriver Cumulatives.")
 	customMetricsPrefix = "custom.googleapis.com"
 )
 
@@ -70,7 +72,7 @@ func main() {
 	defer glog.Flush()
 	flag.Parse()
 
-	sourceConfigs := config.SourceConfigsFromFlags(source, component, host, port, whitelisted)
+	sourceConfigs := config.SourceConfigsFromFlags(source, component, host, port, whitelisted, gaugeToCumulativeWhitelist)
 
 	gceConf, err := config.GetGceConfig(*metricsPrefix)
 	podConfig := &config.PodConfig{
@@ -113,10 +115,18 @@ func main() {
 
 func readAndPushDataToStackdriver(stackdriverService *v3.Service, gceConf *config.GceConfig, podConfig *config.PodConfig, sourceConfig config.SourceConfig) {
 	glog.Infof("Running prometheus-to-sd, monitored target is %s %v:%v", sourceConfig.Component, sourceConfig.Host, sourceConfig.Port)
+
+	// Parse whitelist for metrics that will undergo Prometheus Gauge to Stackdriver Cumulative translation.
+        var gaugeToCumulativeWhitelistedList []string
+	if gaugeToCumulatativeWhitelist != "" {
+		gaugeToCumulativeWhitelistedList = strings.Split(gaugeToCumulativeWhitelist, ",")
+	}
+
 	commonConfig := &config.CommonConfig{
 		GceConfig:     gceConf,
 		PodConfig:     podConfig,
 		ComponentName: sourceConfig.Component,
+		GaugetoCumulativeWhitelist: gaugeToCumulativeWhitelistedList,
 	}
 	metricDescriptorCache := translator.NewMetricDescriptorCache(stackdriverService, commonConfig, sourceConfig.Component)
 	signal := time.After(0)
@@ -153,7 +163,7 @@ func readAndPushDataToStackdriver(stackdriverService *v3.Service, gceConf *confi
 		if strings.HasPrefix(commonConfig.GceConfig.MetricsPrefix, customMetricsPrefix) {
 			metricDescriptorCache.UpdateMetricDescriptors(metrics, sourceConfig.Whitelisted)
 		}
-		ts := translator.TranslatePrometheusToStackdriver(commonConfig, sourceConfig.Whitelisted, metrics, metricDescriptorCache)
+		ts := translator.TranslatePrometheusToStackdriver(commonConfig, sourceConfig.Whitelisted, gaugeToCumulativeWhitelistedList, metrics, metricDescriptorCache)
 		translator.SendToStackdriver(stackdriverService, commonConfig, ts)
 	}
 }

--- a/prometheus-to-sd/main.go
+++ b/prometheus-to-sd/main.go
@@ -72,7 +72,7 @@ func main() {
 	defer glog.Flush()
 	flag.Parse()
 
-	sourceConfigs := config.SourceConfigsFromFlags(source, component, host, port, whitelisted, gaugeToCumulativeWhitelist)
+	sourceConfigs := config.SourceConfigsFromFlags(source, component, host, port, whitelisted)
 
 	gceConf, err := config.GetGceConfig(*metricsPrefix)
 	podConfig := &config.PodConfig{
@@ -163,7 +163,7 @@ func readAndPushDataToStackdriver(stackdriverService *v3.Service, gceConf *confi
 		if strings.HasPrefix(commonConfig.GceConfig.MetricsPrefix, customMetricsPrefix) {
 			metricDescriptorCache.UpdateMetricDescriptors(metrics, sourceConfig.Whitelisted)
 		}
-		ts := translator.TranslatePrometheusToStackdriver(commonConfig, sourceConfig.Whitelisted, gaugeToCumulativeWhitelistedList, metrics, metricDescriptorCache)
+		ts := translator.TranslatePrometheusToStackdriver(commonConfig, sourceConfig.Whitelisted, metrics, metricDescriptorCache)
 		translator.SendToStackdriver(stackdriverService, commonConfig, ts)
 	}
 }

--- a/prometheus-to-sd/main.go
+++ b/prometheus-to-sd/main.go
@@ -118,7 +118,7 @@ func readAndPushDataToStackdriver(stackdriverService *v3.Service, gceConf *confi
 
 	// Parse whitelist for metrics that will undergo Prometheus Gauge to Stackdriver Cumulative translation.
         var gaugeToCumulativeWhitelistedList []string
-	if gaugeToCumulativeWhitelist != "" {
+	if *gaugeToCumulativeWhitelist != "" {
 		gaugeToCumulativeWhitelistedList = strings.Split(*gaugeToCumulativeWhitelist, ",")
 	}
 

--- a/prometheus-to-sd/main.go
+++ b/prometheus-to-sd/main.go
@@ -118,8 +118,8 @@ func readAndPushDataToStackdriver(stackdriverService *v3.Service, gceConf *confi
 
 	// Parse whitelist for metrics that will undergo Prometheus Gauge to Stackdriver Cumulative translation.
         var gaugeToCumulativeWhitelistedList []string
-	if gaugeToCumulatativeWhitelist != "" {
-		gaugeToCumulativeWhitelistedList = strings.Split(gaugeToCumulativeWhitelist, ",")
+	if gaugeToCumulativeWhitelist != "" {
+		gaugeToCumulativeWhitelistedList = strings.Split(*gaugeToCumulativeWhitelist, ",")
 	}
 
 	commonConfig := &config.CommonConfig{

--- a/prometheus-to-sd/main.go
+++ b/prometheus-to-sd/main.go
@@ -126,7 +126,7 @@ func readAndPushDataToStackdriver(stackdriverService *v3.Service, gceConf *confi
 		GceConfig:     gceConf,
 		PodConfig:     podConfig,
 		ComponentName: sourceConfig.Component,
-		GaugetoCumulativeWhitelist: gaugeToCumulativeWhitelistedList,
+		GaugeToCumulativeWhitelist: gaugeToCumulativeWhitelistedList,
 	}
 	metricDescriptorCache := translator.NewMetricDescriptorCache(stackdriverService, commonConfig, sourceConfig.Component)
 	signal := time.After(0)

--- a/prometheus-to-sd/translator/translator.go
+++ b/prometheus-to-sd/translator/translator.go
@@ -146,7 +146,6 @@ func translateOne(config *config.CommonConfig,
 	// Prometheus Cumulative -> Stackdriver Gauge translation
 	if metricKind == "GAUGE" && isMetricGaugeToCumulativeWhitelisted(name, config) {
 		metricKind = "CUMULATIVE"
-		interval.StartTime = start.UTC().Format(time.RFC3339)
 	}
 	if metricKind == "CUMULATIVE" {
 		interval.StartTime = start.UTC().Format(time.RFC3339)
@@ -327,7 +326,7 @@ func getResourceLabels(config *config.CommonConfig) map[string]string {
 	}
 }
 
-// Checks if a metric is whitelisted for Gauge -> Cumulative translation.
+// isMetricGaugeToCumulativeWhitelisted checks if a metric is whitelisted for Gauge -> Cumulative translation.
 func isMetricGaugeToCumulativeWhitelisted(name string, config *config.CommonConfig) bool {
 	for _, metricName := range config.GaugeToCumulativeWhitelist {
 		if metricName == name {

--- a/prometheus-to-sd/translator/translator.go
+++ b/prometheus-to-sd/translator/translator.go
@@ -143,6 +143,11 @@ func translateOne(config *config.CommonConfig,
 		EndTime: time.Now().UTC().Format(time.RFC3339),
 	}
 	metricKind := extractMetricKind(mType)
+	// Prometheus Cumulative -> Stackdriver Gauge translation
+	if metricKind == "GAUGE" && isMetricGaugeToCumulativeWhitelisted(name, config) {
+		metricKind = "CUMULATIVE"
+		interval.StartTime = start.UTC().Format(time.RFC3339)
+	}
 	if metricKind == "CUMULATIVE" {
 		interval.StartTime = start.UTC().Format(time.RFC3339)
 	}
@@ -320,4 +325,14 @@ func getResourceLabels(config *config.CommonConfig) map[string]string {
 		"pod_id":         config.PodConfig.PodId,
 		"container_name": "",
 	}
+}
+
+// Checks if a metric is whitelisted for Gauge -> Cumulative translation.
+func isMetricGaugeToCumulativeWhitelisted(name string, config *config.CommonConfig) bool {
+	for _, metricName := range config.GaugeToCumulativeWhitelist {
+		if metricName == name {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Adds a new flag which takes in a comma-separated list of metric names. These are the metrics which will undergo Prometheus Gauge -> Stackdriver Cumulative translation. This entails the following:

1. The value will get a process_start_time_seconds timestamp (just like a Cumulative). 
2. The value of the Gauge will directly translate over to the Cumulative value. No extra processing is necessary.
3. This will not work for metrics being pushed to custom.googleapis.com. That is because this change will break some of the logic in the metric_descriptor_cache.go. However, this change is only meant to be used for Google internal endpoints. A warning is given above the flag definition that this is the case.