### PR TITLE
Avoid increasing successfully sent metric for event exporter internal logs

### DIFF
--- a/event-exporter/Makefile
+++ b/event-exporter/Makefile
@@ -19,7 +19,7 @@ BINARY_NAME = event-exporter
 
 PREFIX = gcr.io/google-containers
 IMAGE_NAME = event-exporter
-TAG = v0.1.7
+TAG = v0.1.8
 
 build:
 	${ENVVAR} godep go build -a -o ${BINARY_NAME}

--- a/event-exporter/sinks/stackdriver/sink.go
+++ b/event-exporter/sinks/stackdriver/sink.go
@@ -117,8 +117,9 @@ func (s *sdSink) OnDelete(*api_v1.Event) {
 
 func (s *sdSink) OnList(list *api_v1.EventList) {
 	if s.beforeFirstList {
-		s.logEntryChannel <- s.logEntryFactory.FromMessage("Event exporter started watching. " +
+		entry := s.logEntryFactory.FromMessage("Event exporter started watching. " +
 			"Some events may have been lost up to this point.")
+		s.writer.Write([]*sd.LogEntry{entry}, s.logName, s.config.Resource)
 		s.beforeFirstList = false
 	}
 }


### PR DESCRIPTION
This PR removes increasing `successfully_sent_entry_count` metric when sending "event exported started watching".

This way we achieve desirable behavior of having equal `received_entry_count` `successfully_sent_entry_count` metrics.