### PR TITLE
Fix example command

### DIFF
--- a/custom-metrics-stackdriver-adapter/examples/direct-to-sd/README.md
+++ b/custom-metrics-stackdriver-adapter/examples/direct-to-sd/README.md
@@ -25,7 +25,7 @@ The example can be used to test your custom metrics setup using Stackdriver. See
 
 Running 
 ```
-kubectl create -f https://github.com/GoogleCloudPlatform/k8s-stackdriver/blob/master/custom-metrics-stackdriver-adapter/examples/direct-to-sd/custom-metrics-sd.yaml 
+kubectl create -f https://raw.githubusercontent.com/GoogleCloudPlatform/k8s-stackdriver/master/custom-metrics-stackdriver-adapter/examples/direct-to-sd/custom-metrics-sd.yaml
 ```
 will create a custom-metric-sd deployment containing sd_dummy_exporter container.
 Additionally it will create the HPA object to tell Kubernetes to scale

--- a/custom-metrics-stackdriver-adapter/examples/prometheus-to-sd/README.md
+++ b/custom-metrics-stackdriver-adapter/examples/prometheus-to-sd/README.md
@@ -54,7 +54,7 @@ The example can be used to test your custom metrics setup using Stackdriver. See
 
 Running 
 ```
-kubectl create -f https://github.com/GoogleCloudPlatform/k8s-stackdriver/blob/master/custom-metrics-stackdriver-adapter/examples/prometheus-to-sd/custom-metrics-prometheus-sd.yaml 
+kubectl create -f https://raw.githubusercontent.com/GoogleCloudPlatform/k8s-stackdriver/master/custom-metrics-stackdriver-adapter/examples/prometheus-to-sd/custom-metrics-prometheus-sd.yaml 
 ```
 will create a custom-metric-prometheus-sd deployment containing prometheus_dummy_exporter container and a sidecar prometheus-to-sd container.
 Additionally it will create the HPA object to tell Kubernetes to scale the deployment based on the exported metric. Default maximum number of


### PR DESCRIPTION
Existing command doesn't work:

$ kubectl create -f https://github.com/GoogleCloudPlatform/k8s-stackdriver/blob/master/custom-metrics-stackdriver-adapter/examples/direct-to-sd/custom-metrics-sd.yaml 

error: error converting YAML to JSON: yaml: line 314: mapping values are not allowed in this context

Using raw successfully starts exporter pod.