### PR TITLE
remove get from kubectl logs

### DIFF
--- a/custom-metrics-stackdriver-adapter/examples/direct-to-sd/README.md
+++ b/custom-metrics-stackdriver-adapter/examples/direct-to-sd/README.md
@@ -49,7 +49,7 @@ Make sure that:
   * name starts with ```custom.googleapis.com/``` prefix
 * There are no errors when writing your metrics to Stackdriver.
 ```
-kubectl get logs custom-metric-sd
+kubectl logs custom-metric-sd
 ```
 Search for "Failed to write time series data" in the logs
 


### PR DESCRIPTION
I think that logs is a kubectl command and not a resource that you load with the get command.