### PR TITLE
Update prom-to-sd to latest base image

### DIFF
--- a/prometheus-to-sd/Dockerfile
+++ b/prometheus-to-sd/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/google-containers/debian-base-amd64:0.1
+FROM gcr.io/google-containers/debian-base-amd64:0.3
 
 RUN clean-install ca-certificates
 


### PR DESCRIPTION
This should use the latest base to get the latest CVE fixes