### PR TITLE
Remove hack to copy systemd libraries from host in fluentd-gcp container.

### DIFF
--- a/fluentd-gcp-image/Makefile
+++ b/fluentd-gcp-image/Makefile
@@ -26,7 +26,7 @@
 .PHONY:	build push
 
 PREFIX=gcr.io/google-containers
-TAG = 2.0.15
+TAG = 2.0.16
 
 build:
 	docker build --pull -t $(PREFIX)/fluentd-gcp:$(TAG) .

--- a/fluentd-gcp-image/run.sh
+++ b/fluentd-gcp-image/run.sh
@@ -20,10 +20,4 @@
 # For systems without journald
 mkdir -p /var/log/journal
 
-# Copy host libsystemd into image to avoid compatibility issues.
-if [ ! -z "$(ls /host/lib/libsystemd* 2>/dev/null)" ]; then
-  rm /lib/x86_64-linux-gnu/libsystemd*
-  cp -a /host/lib/libsystemd* /lib/x86_64-linux-gnu/
-fi
-
-/usr/local/bin/fluentd $@
+exec /usr/local/bin/fluentd "$@"


### PR DESCRIPTION
Remove hack to copy systemd libraries from host in fluentd-gcp container. That hack was present to make fluentd-gcp be able to access journal files from COS, which are created using LZ4 compression. But debian-base:0.3 (on which this is now based) already supports both +XZ and +LZ4 compression, so this hack is no longer needed.

That hack breaks on, say, CentOS 7, where the systemd libraries link to other versions of libraries that are not available in the fluentd-gcp.

For more context, see some discussion [here](https://github.com/kubernetes/kubernetes/pull/41407#issuecomment-363971712).

Also clean up the /run.sh shell script and effectively stop using it altogether (though still ship it, for compatibility.) See individual commits for the individual cleanup steps.

Bump version to 2.0.16 to incorporate these changes.

cc @crassirostris who introduced the /host/lib hack to this container.
cc @adityakali to help test this in COS.
cc @x13n who pushed latest changes to this container. (Can you help us build official versions with these commits?)
cc @tallclair who bumped debian-base from 0.1 to 0.3 in this container.
