### PR TITLE
Add RBAC for HPA Controller to read external metrics

### DIFF
--- a/custom-metrics-stackdriver-adapter/adapter-staging.yaml
+++ b/custom-metrics-stackdriver-adapter/adapter-staging.yaml
@@ -138,3 +138,30 @@ spec:
     name: custom-metrics-stackdriver-adapter
     namespace: custom-metrics
   version: v1beta1
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-metrics-reader
+rules:
+- apiGroups:
+  - "external.metrics.k8s.io"
+  resources:
+  - "*"
+  verbs:
+  - list
+  - get
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: external-metrics-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: horizontal-pod-autoscaler
+  namespace: kube-system


### PR DESCRIPTION
Add a role for external metrics reader.
Bind HPA Controller to that role.

Without this, HPA controller does not have permission to read external metrics api.