### PR TITLE
Force go_import_path for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: required
 
+go_import_path: github.com/GoogleCloudPlatform/k8s-stackdriver
+
 services:
   - docker
 


### PR DESCRIPTION
This allows for easy testing of github forks, even before
submitting pull requests.