### PR TITLE
Bump Custom Metrics - Stackdriver Adapter to v0.5.0

### DIFF
--- a/custom-metrics-stackdriver-adapter/Makefile
+++ b/custom-metrics-stackdriver-adapter/Makefile
@@ -2,7 +2,7 @@ ARCH?=amd64
 OUT_DIR?=build
 PACKAGE=github.com/GoogleCloudPlatform/k8s-stackdriver/custom-metrics-stackdriver-adapter
 PREFIX?=gcr.io/google-containers
-TAG = v0.4.0
+TAG = v0.5.0
 PKG := $(shell find pkg/* -type f)
 
 .PHONY: build docker push test clean

--- a/custom-metrics-stackdriver-adapter/deploy/staging/adapter_new_resource_model.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/staging/adapter_new_resource_model.yaml
@@ -76,7 +76,7 @@ spec:
     spec:
       serviceAccountName: custom-metrics-stackdriver-adapter
       containers:
-      - image: gcr.io/google-containers/custom-metrics-stackdriver-adapter:staging
+      - image: gcr.io/google-containers/custom-metrics-stackdriver-adapter:v0.5.0
         imagePullPolicy: Always
         name: pod-custom-metrics-stackdriver-adapter
         command:

--- a/custom-metrics-stackdriver-adapter/deploy/staging/adapter_old_resource_model.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/staging/adapter_old_resource_model.yaml
@@ -76,7 +76,7 @@ spec:
     spec:
       serviceAccountName: custom-metrics-stackdriver-adapter
       containers:
-      - image: gcr.io/google-containers/custom-metrics-stackdriver-adapter:staging
+      - image: gcr.io/google-containers/custom-metrics-stackdriver-adapter:v0.5.0
         imagePullPolicy: Always
         name: pod-custom-metrics-stackdriver-adapter
         command:


### PR DESCRIPTION
This bumps the adapter image to v0.5.0 and uses newest version in staging deployments.