### PR TITLE
Add information on External Metrics do documentation.

### DIFF
--- a/custom-metrics-stackdriver-adapter/README.md
+++ b/custom-metrics-stackdriver-adapter/README.md
@@ -1,8 +1,8 @@
 # Custom Metrics - Stackdriver Adapter
 
 Custom Metrics - Stackdriver Adapter is an implementation of [Custom Metrics
-API] based on Stackdriver per-pod metrics. It's purpose is to enable pod
-autoscaling based on Stackdriver custom metrics.
+API] and [External Metrics API] using Stackdriver as a backend. Its purpose is
+to enable pod autoscaling based on Stackdriver custom metrics.
 
 ## Usage guide
 
@@ -45,14 +45,46 @@ them to scale your application, following [HPA walkthrough].
      - To set scopes in existing clusters you can use `gcloud beta compute
        instances set-scopes` command, see [gcloud
        documentation](https://cloud.google.com/sdk/gcloud/reference/beta/compute/instances/set-scopes).
+    * On GKE, you need cluster-admin permissions on your cluster. You can grant
+      your user account these permissions with following command:
+      ```
+      kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-admin --user $(gcloud config get-value account)
+      ```
 
 1. Start *Custom Metrics - Stackdriver Adapter*.
 
 ```sh
-kubectl create -f https://raw.githubusercontent.com/GoogleCloudPlatform/k8s-stackdriver/master/custom-metrics-stackdriver-adapter/adapter-beta.yaml
+kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/k8s-stackdriver/master/custom-metrics-stackdriver-adapter/deploy/production/adapter.yaml
 ```
 
-### Export metrics to Stackdriver
+### Metrics available from Stackdriver
+
+Custom Metrics - Stackdriver Adapter exposes Stackdriver metrics to Kubernetes
+components via two APIs.
+
+1. Any Stackdriver metric can be retrieved via **External Metrics API** with one
+   assumption: `metricType = DOUBLE` or `INT64`. For example, this API can be
+   used to configure Horizontal Pod Autoscaler to scale deployment based on any
+   of [existing metrics from other GCP services].
+
+1. Metrics attached to Kubernetes objects, such as Pod or Node, can be retrieved
+   via **Custom Metrics API**. The following section provides more details about
+   exporting such metrics.
+
+#### Metric kinds
+
+Stackdriver specifies three metric kinds, all of which are supported by Custom
+Metrics - Stackdriver Adapter:
+1. `GAUGE` - Each data point represents an instantaneous measurement, for
+   example the temperature. The adapter exposes the latest value.
+1. `DELTA` - Each data point represents the change in a value over the time
+   interval. The adapter exposes *rate* of the metric - the metric change per
+   second computed over last 5 minutes.
+1. `CUMULATIVE` - Each data point is a value being accumulated over time. The
+   adapter exposes *rate* of the metric - the metric change per second computed
+   over last 5 minutes.
+
+### Export custom metrics to Stackdriver
 
 To learn how to create your custom metric and write your data to Stackdriver,
 follow [Stackdriver custom metrics documentation]. You can also follow
@@ -64,7 +96,6 @@ by a simple name, as defined in [custom metric naming rules].
 
 1. Define your custom metric by following [Stackdriver custom metrics documentation].
    Your metric descriptor needs to meet following requirements:
-   * `metricKind = GAUGE`
    * `metricType = DOUBLE` or `INT64`
 1. Export metric from your application. The metric has to be associated with a
    specific pod and meet folowing requirements:
@@ -166,7 +197,7 @@ by a simple name, as defined in [custom metric naming rules].
      stackdriverService.Projects.TimeSeries.Create("projects/<your project ID>", request).Do()
      ```
 
-#### Examples
+### Examples
 
 To test your custom metrics setup or see a reference on how to push your metrics
 to Stackdriver, check out our examples:
@@ -177,6 +208,8 @@ to Stackdriver, check out our examples:
 
 [Custom Metrics API]:
 https://github.com/kubernetes/metrics/tree/master/pkg/apis/custom_metrics
+[External Metrics API]:
+https://github.com/kubernetes/metrics/tree/master/pkg/apis/external_metrics
 [HPA walkthrough]:
 https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/
 [cluster setup]: https://kubernetes.io/docs/setup/
@@ -200,3 +233,5 @@ https://cloud.google.com/monitoring/api/resources
 https://github.com/GoogleCloudPlatform/k8s-stackdriver/tree/master/prometheus-to-sd
 [Prometheus text format]:
 https://prometheus.io/docs/instrumenting/exposition_formats
+[existing metrics from other GCP services]:
+https://cloud.google.com/monitoring/api/metrics_gcp

--- a/custom-metrics-stackdriver-adapter/deploy/production/adapter.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/production/adapter.yaml
@@ -72,11 +72,12 @@ spec:
     spec:
       serviceAccountName: custom-metrics-stackdriver-adapter
       containers:
-      - image: gcr.io/google-containers/custom-metrics-stackdriver-adapter:v0.4.0
+      - image: gcr.io/google-containers/custom-metrics-stackdriver-adapter:v0.6.0
         imagePullPolicy: Always
         name: pod-custom-metrics-stackdriver-adapter
         command:
         - /adapter
+        - --use-new-resource-model=false
         resources:
           limits:
             cpu: 250m
@@ -119,3 +120,45 @@ spec:
     name: custom-metrics-stackdriver-adapter
     namespace: custom-metrics
   version: v1beta1
+---
+apiVersion: apiregistration.k8s.io/v1beta1
+kind: APIService
+metadata:
+  name: v1beta1.external.metrics.k8s.io
+spec:
+  insecureSkipTLSVerify: true
+  group: external.metrics.k8s.io
+  groupPriorityMinimum: 100
+  versionPriority: 100
+  priority: 100
+  service:
+    name: custom-metrics-stackdriver-adapter
+    namespace: custom-metrics
+  version: v1beta1
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-metrics-reader
+rules:
+- apiGroups:
+  - "external.metrics.k8s.io"
+  resources:
+  - "*"
+  verbs:
+  - list
+  - get
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: external-metrics-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: horizontal-pod-autoscaler
+  namespace: kube-system


### PR DESCRIPTION
This PR:
- Updates deploy/production/adapter.yaml deployment to v0.5.0
- Changes recommended deployment from adapter-beta.yaml to deploy/production/adapter.yaml
- Adds information that External Metrics API is now supported