### PR TITLE
Bump version of prometheus-to-sd and kubelet-to-gcm.

### DIFF
--- a/kubelet-to-gcm/Makefile
+++ b/kubelet-to-gcm/Makefile
@@ -25,7 +25,7 @@
 OUT_DIR = build
 PACKAGE = github.com/GoogleCloudPlatform/k8s-stackdriver/kubelet-to-gcm
 PREFIX = gcr.io/google-containers
-TAG = 1.2.4
+TAG = 1.2.5
 
 # Rules for building the real image for deployment to gcr.io
 

--- a/prometheus-to-sd/Makefile
+++ b/prometheus-to-sd/Makefile
@@ -16,7 +16,7 @@ all: build
 
 ENVVAR = GOOS=linux GOARCH=amd64 CGO_ENABLED=0
 PREFIX = gcr.io/google-containers
-TAG = v0.2.5
+TAG = v0.2.6
 
 build:
 	$(ENVVAR) godep go build -a -o monitor


### PR DESCRIPTION
This releases includes correct instance name.