### PR TITLE
event exporter fix cluster location trailing whitespace

### DIFF
--- a/event-exporter/Makefile
+++ b/event-exporter/Makefile
@@ -19,7 +19,7 @@ BINARY_NAME = event-exporter
 
 PREFIX = gcr.io/google-containers
 IMAGE_NAME = event-exporter
-TAG = v0.2.0
+TAG = v0.2.1
 
 build:
 	${ENVVAR} godep go build -a -o ${BINARY_NAME}

--- a/event-exporter/sinks/stackdriver/monitored_resource_factory_config.go
+++ b/event-exporter/sinks/stackdriver/monitored_resource_factory_config.go
@@ -28,7 +28,8 @@ func newMonitoredResourceFactoryConfig(resourceModelVersion string) (*monitoredR
 	}
 
 	location, err := metadata.InstanceAttributeValue("cluster-location")
-	if err != nil {
+	location = strings.TrimSpace(location)
+	if err != nil || location == "" {
 		glog.Warningf("Failed to retrieve cluster location, falling back to local zone: %s", err)
 		location, err = metadata.Zone()
 		if err != nil {


### PR DESCRIPTION
event exporter fix cluster location trailing whitespace

plus patch version bump