### PR TITLE
Allow missing usageNanoCores

### DIFF
--- a/kubelet-to-gcm/monitor/kubelet/translate.go
+++ b/kubelet-to-gcm/monitor/kubelet/translate.go
@@ -260,9 +260,6 @@ func translateCPU(cpu *stats.CPUStats, tsFactory *timeSeriesFactory, startTime t
 	if cpu == nil {
 		return nil, fmt.Errorf("CPU information missing.")
 	}
-	if cpu.UsageNanoCores == nil {
-		return nil, fmt.Errorf("UsageNanoCores missing from CPUStats %v", cpu)
-	}
 	if cpu.UsageCoreNanoSeconds == nil {
 		return nil, fmt.Errorf("UsageCoreNanoSeconds missing from CPUStats %v", cpu)
 	}

--- a/kubelet-to-gcm/monitor/kubelet/translate_test.go
+++ b/kubelet-to-gcm/monitor/kubelet/translate_test.go
@@ -201,8 +201,8 @@ func TestTranslator(t *testing.T) {
 }
 
 func TestTranslateContainers(t *testing.T) {
-	aliceContainer := *getContainerStats()
-	bobContainer := *getContainerStats()
+	aliceContainer := *getContainerStats(false)
+	bobContainer := *getContainerStats(false)
 	tsPerContainer := 11
 	testCases := []struct {
 		name            string
@@ -226,6 +226,13 @@ func TestTranslateContainers(t *testing.T) {
 			ExpectedTSCount: tsPerContainer,
 			pods: []stats.PodStats{
 				getPodStats(aliceContainer),
+			},
+		},
+		{
+			name:            "single pod with one container without usageNanoCores",
+			ExpectedTSCount: tsPerContainer,
+			pods: []stats.PodStats{
+				getPodStats(*getContainerStats(true)),
 			},
 		},
 		{
@@ -286,10 +293,13 @@ func getPodStats(containers ...stats.ContainerStats) stats.PodStats {
 	}
 }
 
-func getContainerStats() *stats.ContainerStats {
+func getContainerStats(skipUsageNanoCores bool) *stats.ContainerStats {
 	f := fuzz.New().NilChance(0)
 	v := &stats.ContainerStats{}
 	f.Fuzz(v)
+	if skipUsageNanoCores {
+		v.CPU.UsageNanoCores = nil
+	}
 	return v
 }
 


### PR DESCRIPTION
CAdvisor skips that metric on fresh containers, when he didn't have time
to calculate it.

closes https://github.com/GoogleCloudPlatform/k8s-stackdriver/issues/160