### PR TITLE
Bum version of kubelet-to-gcm to 1.2.6

### DIFF
--- a/kubelet-to-gcm/Makefile
+++ b/kubelet-to-gcm/Makefile
@@ -25,7 +25,7 @@
 OUT_DIR = build
 PACKAGE = github.com/GoogleCloudPlatform/k8s-stackdriver/kubelet-to-gcm
 PREFIX = gcr.io/google-containers
-TAG = 1.2.5
+TAG = 1.2.6
 
 # Rules for building the real image for deployment to gcr.io
 


### PR DESCRIPTION
CHANGELOG
```
* Fix dropping metrics for containers with same name (https://github.com/GoogleCloudPlatform/k8s-stackdriver/issues/161)
* Fix failing to send metrics after container was just created/restarted (https://github.com/GoogleCloudPlatform/k8s-stackdriver/issues/160)
```