### PR TITLE
[Custom Metrics] Remove priority field from apiservice definitions

### DIFF
--- a/custom-metrics-stackdriver-adapter/deploy/production/adapter.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/production/adapter.yaml
@@ -115,7 +115,6 @@ spec:
   group: custom.metrics.k8s.io
   groupPriorityMinimum: 100
   versionPriority: 100
-  priority: 100
   service:
     name: custom-metrics-stackdriver-adapter
     namespace: custom-metrics
@@ -130,7 +129,6 @@ spec:
   group: external.metrics.k8s.io
   groupPriorityMinimum: 100
   versionPriority: 100
-  priority: 100
   service:
     name: custom-metrics-stackdriver-adapter
     namespace: custom-metrics

--- a/custom-metrics-stackdriver-adapter/deploy/staging/adapter_new_resource_model.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/staging/adapter_new_resource_model.yaml
@@ -119,7 +119,6 @@ spec:
   group: custom.metrics.k8s.io
   groupPriorityMinimum: 100
   versionPriority: 100
-  priority: 100
   service:
     name: custom-metrics-stackdriver-adapter
     namespace: custom-metrics
@@ -134,7 +133,6 @@ spec:
   group: external.metrics.k8s.io
   groupPriorityMinimum: 100
   versionPriority: 100
-  priority: 100
   service:
     name: custom-metrics-stackdriver-adapter
     namespace: custom-metrics

--- a/custom-metrics-stackdriver-adapter/deploy/staging/adapter_old_resource_model.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/staging/adapter_old_resource_model.yaml
@@ -119,7 +119,6 @@ spec:
   group: custom.metrics.k8s.io
   groupPriorityMinimum: 100
   versionPriority: 100
-  priority: 100
   service:
     name: custom-metrics-stackdriver-adapter
     namespace: custom-metrics
@@ -134,7 +133,6 @@ spec:
   group: external.metrics.k8s.io
   groupPriorityMinimum: 100
   versionPriority: 100
-  priority: 100
   service:
     name: custom-metrics-stackdriver-adapter
     namespace: custom-metrics


### PR DESCRIPTION
This caused Custom Metrics - Stackdriver Adapter e2e tests to fail.