### PR TITLE
[prometheus-to-sd] Allow using prometheus labels for SD resource

### DIFF
--- a/hack/verify-flags/exceptions.txt
+++ b/hack/verify-flags/exceptions.txt
@@ -36,5 +36,5 @@ kubelet-to-gcm/monitor/kubelet/translate.go:		"namespace_id":   "",
 kubelet-to-gcm/monitor/kubelet/translate.go:		"pod_id":         "machine",
 prometheus-to-sd/README.md:the prometheus-to-sd. Values of the `namespace_id` and `pod_id` can be passed to
 prometheus-to-sd/translator/metrics.go:		[]string{"component_name", "metric_name"},
-prometheus-to-sd/translator/translator.go:		"namespace_id":   config.PodConfig.NamespaceId,
-prometheus-to-sd/translator/translator.go:		"pod_id":         config.PodConfig.PodId,
+prometheus-to-sd/translator/translator.go:		"namespace_id":   namespace,
+prometheus-to-sd/translator/translator.go:		"pod_id":         pod,

--- a/prometheus-to-sd/README.md
+++ b/prometheus-to-sd/README.md
@@ -55,3 +55,18 @@ Example of [deployment](https://github.com/GoogleCloudPlatform/k8s-stackdriver/b
 used to monitor
 [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) component, that is used to collect
 different metrics about the state of k8s cluster.
+
+## Container monitoring agents
+
+Container monitoring agents, such as [cAdvisor](https://github.com/google/cadvisor#cadvisor), 
+collect metrics about containers other than itself.  Monitoring agents use prometheus
+labels for the namespace, pod, and container to differentiate metrics from different
+containers.  To use these prometheus labels as the monitored resource labels in
+stackdriver, include `namespaceIdLabel`, `podIdLabel`, and `containerNameLabel` in the 
+`source` flag in this format: 
+`component-name:http://host:port?whitelisted=a,b,c&namespaceIdLabel=d&podIdLabel=e&containerNameLabel=f`.
+Note that prometheus labels used for the monitored resource are not included as labels in stackdriver.
+
+For example, if prom-to-sd scraped the prometheus metric: 
+`container_cpu_usage_seconds{d="my-namespace",e="abc123",f="my-app",g="production"} 1.02030405e+09`
+It would be displayed in stackdriver with the namespace, `my-namespace`, the pod id, `abc123`, and the container name, `my-app`.  The only stackdriver label for this metric would be `g="production"`.

--- a/prometheus-to-sd/config/common_config.go
+++ b/prometheus-to-sd/config/common_config.go
@@ -16,10 +16,61 @@ limitations under the License.
 
 package config
 
+import (
+	dto "github.com/prometheus/client_model/go"
+)
+
+// PodConfig can identify metric and resource information for pods.
+type PodConfig interface {
+	// IsMetricLabel returns true if the label name should be added as a metric label
+	IsMetricLabel(labelName string) bool
+
+	// GetPodInfo returns the information required to identify the pod.
+	GetPodInfo(labels []*dto.LabelPair) (containerName, podId, namespaceId string)
+}
+
+// NewPodConfig returns a PodConfig which uses for the provided pod, namespace, and container label values,
+// if found, and falls back to the podId and namespaceId.
+func NewPodConfig(podId, namespaceId, podIdLabel, namespaceIdLabel, containerNameLabel string) PodConfig {
+	return &podConfigImpl{
+		podId:              podId,
+		namespaceId:        namespaceId,
+		podIdLabel:         podIdLabel,
+		namespaceIdLabel:   namespaceIdLabel,
+		containerNameLabel: containerNameLabel,
+	}
+}
+
+type podConfigImpl struct {
+	podId              string
+	namespaceId        string
+	podIdLabel         string
+	namespaceIdLabel   string
+	containerNameLabel string
+}
+
+func (p *podConfigImpl) IsMetricLabel(labelName string) bool {
+	return labelName != p.podIdLabel && labelName != p.containerNameLabel && labelName != p.namespaceIdLabel
+}
+
+func (p *podConfigImpl) GetPodInfo(labels []*dto.LabelPair) (containerName, podId, namespaceId string) {
+	containerName, podId, namespaceId = "", p.podId, p.namespaceId
+	for _, label := range labels {
+		if label.GetName() == p.containerNameLabel && label.GetValue() != "" {
+			containerName = label.GetValue()
+		} else if label.GetName() == p.podIdLabel && label.GetValue() != "" {
+			podId = label.GetValue()
+		} else if label.GetName() == p.namespaceIdLabel && label.GetValue() != "" {
+			namespaceId = label.GetValue()
+		}
+	}
+	return containerName, podId, namespaceId
+}
+
 // CommonConfig contains all required information about environment in which
 // prometheus-to-sd running and which component is monitored.
 type CommonConfig struct {
 	GceConfig     *GceConfig
-	PodConfig     *PodConfig
+	PodConfig     PodConfig
 	ComponentName string
 }

--- a/prometheus-to-sd/config/dynamic_source.go
+++ b/prometheus-to-sd/config/dynamic_source.go
@@ -83,11 +83,7 @@ func getConfigsFromPods(pods []core.Pod, sources map[string]url.URL) []SourceCon
 	for _, pod := range pods {
 		componentName := pod.Labels[nameLabel]
 		source, _ := sources[componentName]
-		podConfig := PodConfig{
-			PodId:       pod.Name,
-			NamespaceId: pod.Namespace,
-		}
-		sourceConfig, err := mapToSourceConfig(componentName, source, pod.Status.PodIP, podConfig)
+		sourceConfig, err := mapToSourceConfig(componentName, source, pod.Status.PodIP, pod.Name, pod.Namespace)
 		if err != nil {
 			glog.Warningf("could not create source config for pod %s: %v", pod.Name, err)
 		}
@@ -96,8 +92,12 @@ func getConfigsFromPods(pods []core.Pod, sources map[string]url.URL) []SourceCon
 	return sourceConfigs
 }
 
-func mapToSourceConfig(componentName string, url url.URL, ip string, podConfig PodConfig) (*SourceConfig, error) {
+func mapToSourceConfig(componentName string, url url.URL, ip, podId, namespaceId string) (*SourceConfig, error) {
 	port := url.Port()
 	whitelisted := url.Query().Get("whitelisted")
+	podIdLabel := url.Query().Get("podIdLabel")
+	namespaceIdLabel := url.Query().Get("namespaceIdLabel")
+	containerNamelabel := url.Query().Get("containerNamelabel")
+	podConfig := NewPodConfig(podId, namespaceId, podIdLabel, namespaceIdLabel, containerNamelabel)
 	return newSourceConfig(componentName, ip, port, url.Path, whitelisted, podConfig)
 }

--- a/prometheus-to-sd/config/pod_config_test.go
+++ b/prometheus-to-sd/config/pod_config_test.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2018 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+func TestIsMetricLabel(t *testing.T) {
+	for _, tc := range []struct {
+		desc   string
+		config *podConfigImpl
+		label  string
+		want   bool
+	}{
+		{
+			desc:   "empty",
+			config: &podConfigImpl{},
+			label:  "foo",
+			want:   true,
+		},
+		{
+			desc: "containerNameLabel matches",
+			config: &podConfigImpl{
+				containerNameLabel: "foo",
+				podIdLabel:         "bar",
+				namespaceIdLabel:   "abc",
+			},
+			label: "foo",
+			want:  false,
+		},
+		{
+			desc: "podIdLabel matches",
+			config: &podConfigImpl{
+				containerNameLabel: "foo",
+				podIdLabel:         "bar",
+				namespaceIdLabel:   "abc",
+			},
+			label: "bar",
+			want:  false,
+		},
+		{
+			desc: "namespaceIdLabel matches",
+			config: &podConfigImpl{
+				containerNameLabel: "foo",
+				podIdLabel:         "bar",
+				namespaceIdLabel:   "abc",
+			},
+			label: "abc",
+			want:  false,
+		},
+		{
+			desc: "none match",
+			config: &podConfigImpl{
+				containerNameLabel: "foo",
+				podIdLabel:         "bar",
+				namespaceIdLabel:   "abc",
+			},
+			label: "xyz",
+			want:  true,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			actual := tc.config.IsMetricLabel(tc.label)
+			if actual != tc.want {
+				t.Fatalf("Unexpected result; got %v, want %v", actual, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetPodInfo(t *testing.T) {
+	container, containerLabel := "container", "cLabel"
+	pod, podLabel := "pod", "pLabel"
+	namespace, namespaceLabel := "namespace", "nLabel"
+	other, otherLabel := "other", "olabel"
+	labels := []*dto.LabelPair{
+		{
+			Name:  &containerLabel,
+			Value: &container,
+		},
+		{
+			Name:  &podLabel,
+			Value: &pod,
+		},
+		{
+			Name:  &otherLabel,
+			Value: &other,
+		},
+		{
+			Name:  &namespaceLabel,
+			Value: &namespace,
+		},
+	}
+	for _, tc := range []struct {
+		desc              string
+		config            *podConfigImpl
+		wantContainerName string
+		wantPodId         string
+		wantNamespaceId   string
+	}{
+		{
+			desc:              "empty",
+			config:            &podConfigImpl{},
+			wantContainerName: "",
+			wantPodId:         "",
+			wantNamespaceId:   "",
+		},
+		{
+			desc: "not matching labels",
+			config: &podConfigImpl{
+				containerNameLabel: "foo",
+				podIdLabel:         "bar",
+				namespaceIdLabel:   "abc",
+			},
+			wantContainerName: "",
+			wantPodId:         "",
+			wantNamespaceId:   "",
+		},
+		{
+			desc: "matching labels",
+			config: &podConfigImpl{
+				containerNameLabel: containerLabel,
+				podIdLabel:         podLabel,
+				namespaceIdLabel:   namespaceLabel,
+			},
+			wantContainerName: container,
+			wantPodId:         pod,
+			wantNamespaceId:   namespace,
+		},
+		{
+			desc: "matching labels w/ podId and namespaceId specified",
+			config: &podConfigImpl{
+				podId:              "podid",
+				namespaceId:        "namespaceid",
+				containerNameLabel: containerLabel,
+				podIdLabel:         podLabel,
+				namespaceIdLabel:   namespaceLabel,
+			},
+			wantContainerName: container,
+			wantPodId:         pod,
+			wantNamespaceId:   namespace,
+		},
+		{
+			desc: "not matching labels w/ podId and namespaceId specified",
+			config: &podConfigImpl{
+				podId:              "podid",
+				namespaceId:        "namespaceid",
+				containerNameLabel: "foo",
+				podIdLabel:         "bar",
+				namespaceIdLabel:   "abc",
+			},
+			wantContainerName: "",
+			wantPodId:         "podid",
+			wantNamespaceId:   "namespaceid",
+		},
+		{
+			desc: "some matching labels w/ podId and namespaceId specified",
+			config: &podConfigImpl{
+				podId:              "podid",
+				namespaceId:        "namespaceid",
+				containerNameLabel: containerLabel,
+				podIdLabel:         "bar",
+				namespaceIdLabel:   "abc",
+			},
+			wantContainerName: container,
+			wantPodId:         "podid",
+			wantNamespaceId:   "namespaceid",
+		},
+		{
+			desc: "podId and namespaceId specified",
+			config: &podConfigImpl{
+				podId:       "podid",
+				namespaceId: "namespaceid",
+			},
+			wantContainerName: "",
+			wantPodId:         "podid",
+			wantNamespaceId:   "namespaceid",
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			container, pod, namespace := tc.config.GetPodInfo(labels)
+			if container != tc.wantContainerName {
+				t.Errorf("Unexpected containerName; got %q, want %q", container, tc.wantContainerName)
+			}
+			if pod != tc.wantPodId {
+				t.Errorf("Unexpected podId; got %q, want %q", pod, tc.wantPodId)
+			}
+			if namespace != tc.wantNamespaceId {
+				t.Errorf("Unexpected namespaceId; got %q, want %q", namespace, tc.wantNamespaceId)
+			}
+		})
+	}
+}

--- a/prometheus-to-sd/config/source_config.go
+++ b/prometheus-to-sd/config/source_config.go
@@ -37,12 +37,6 @@ type SourceConfig struct {
 	PodConfig   PodConfig
 }
 
-// PodConfig describes the pod in which the monitored component is running.
-type PodConfig struct {
-	PodId       string
-	NamespaceId string
-}
-
 const defaultMetricsPath = "/metrics"
 
 // newSourceConfig creates a new SourceConfig based on string representation of fields.
@@ -75,7 +69,7 @@ func newSourceConfig(component string, host string, port string, path string, wh
 }
 
 // parseSourceConfig creates a new SourceConfig based on the provided flags.Uri instance.
-func parseSourceConfig(uri flags.Uri, podConfig PodConfig) (*SourceConfig, error) {
+func parseSourceConfig(uri flags.Uri, podId, namespaceId string) (*SourceConfig, error) {
 	host, port, err := net.SplitHostPort(uri.Val.Host)
 	if err != nil {
 		return nil, err
@@ -85,6 +79,10 @@ func parseSourceConfig(uri flags.Uri, podConfig PodConfig) (*SourceConfig, error
 	values := uri.Val.Query()
 	path := uri.Val.Path
 	whitelisted := values.Get("whitelisted")
+	podIdLabel := values.Get("podIdLabel")
+	namespaceIdLabel := values.Get("namespaceIdLabel")
+	containerNamelabel := values.Get("containerNamelabel")
+	podConfig := NewPodConfig(podId, namespaceId, podIdLabel, namespaceIdLabel, containerNamelabel)
 
 	return newSourceConfig(component, host, port, path, whitelisted, podConfig)
 }
@@ -96,13 +94,9 @@ func (config *SourceConfig) UpdateWhitelistedMetrics(list []string) {
 
 // SourceConfigsFromFlags creates a slice of SourceConfig's base on the provided flags.
 func SourceConfigsFromFlags(source flags.Uris, podId *string, namespaceId *string) []SourceConfig {
-	podConfig := PodConfig{
-		PodId:       *podId,
-		NamespaceId: *namespaceId,
-	}
 	var sourceConfigs []SourceConfig
 	for _, c := range source {
-		if sourceConfig, err := parseSourceConfig(c, podConfig); err != nil {
+		if sourceConfig, err := parseSourceConfig(c, *podId, *namespaceId); err != nil {
 			glog.Fatalf("Error while parsing source config flag %v: %v", c, err)
 		} else {
 			sourceConfigs = append(sourceConfigs, *sourceConfig)

--- a/prometheus-to-sd/config/source_config_test.go
+++ b/prometheus-to-sd/config/source_config_test.go
@@ -26,10 +26,8 @@ import (
 )
 
 func TestNewSourceConfig(t *testing.T) {
-	podConfig := PodConfig{
-		PodId:       "podId",
-		NamespaceId: "namespaceId",
-	}
+	podConfig := NewPodConfig("podId", "namespaceId", "", "", "")
+	emptyPodConfig := NewPodConfig("", "", "", "", "")
 	correct := [...]struct {
 		component   string
 		host        string
@@ -50,34 +48,34 @@ func TestNewSourceConfig(t *testing.T) {
 			},
 		},
 
-		{"testComponent", "localhost", "1234", "/status/prometheus", "", PodConfig{},
+		{"testComponent", "localhost", "1234", "/status/prometheus", "", emptyPodConfig,
 			SourceConfig{
 				Component:   "testComponent",
 				Host:        "localhost",
 				Port:        1234,
 				Path:        "/status/prometheus",
 				Whitelisted: nil,
-				PodConfig:   PodConfig{},
+				PodConfig:   emptyPodConfig,
 			},
 		},
-		{"testComponent", "localhost", "1234", "/", "", PodConfig{},
+		{"testComponent", "localhost", "1234", "/", "", emptyPodConfig,
 			SourceConfig{
 				Component:   "testComponent",
 				Host:        "localhost",
 				Port:        1234,
 				Path:        "/metrics",
 				Whitelisted: nil,
-				PodConfig:   PodConfig{},
+				PodConfig:   emptyPodConfig,
 			},
 		},
-		{"testComponent", "localhost", "1234", "", "", PodConfig{},
+		{"testComponent", "localhost", "1234", "", "", emptyPodConfig,
 			SourceConfig{
 				Component:   "testComponent",
 				Host:        "localhost",
 				Port:        1234,
 				Path:        "/metrics",
 				Whitelisted: nil,
-				PodConfig:   PodConfig{},
+				PodConfig:   emptyPodConfig,
 			},
 		},
 	}
@@ -91,10 +89,8 @@ func TestNewSourceConfig(t *testing.T) {
 }
 
 func TestParseSourceConfig(t *testing.T) {
-	podConfig := PodConfig{
-		PodId:       "podId",
-		NamespaceId: "namespaceId",
-	}
+	podId := "podId"
+	namespaceId := "namespaceId"
 	correct := [...]struct {
 		in     flags.Uri
 		output SourceConfig
@@ -115,7 +111,7 @@ func TestParseSourceConfig(t *testing.T) {
 				Port:        1234,
 				Path:        defaultMetricsPath,
 				Whitelisted: []string{"a", "b", "c", "d"},
-				PodConfig:   podConfig,
+				PodConfig:   NewPodConfig(podId, namespaceId, "", "", ""),
 			},
 		},
 		{
@@ -134,13 +130,13 @@ func TestParseSourceConfig(t *testing.T) {
 				Port:        1234,
 				Path:        "/status/prometheus",
 				Whitelisted: []string{"a", "b", "c", "d"},
-				PodConfig:   podConfig,
+				PodConfig:   NewPodConfig(podId, namespaceId, "", "", ""),
 			},
 		},
 	}
 
 	for _, c := range correct {
-		res, err := parseSourceConfig(c.in, podConfig)
+		res, err := parseSourceConfig(c.in, podId, namespaceId)
 		if assert.NoError(t, err) {
 			assert.Equal(t, c.output, *res)
 		}
@@ -166,7 +162,7 @@ func TestParseSourceConfig(t *testing.T) {
 	}
 
 	for _, c := range incorrect {
-		_, err := parseSourceConfig(c, podConfig)
+		_, err := parseSourceConfig(c, podId, namespaceId)
 		assert.Error(t, err)
 	}
 }

--- a/prometheus-to-sd/main.go
+++ b/prometheus-to-sd/main.go
@@ -67,9 +67,9 @@ var (
 
 func main() {
 	flag.Set("logtostderr", "true")
-	flag.Var(&source, "source", "source(s) to watch in [component-name]:http://host:port/path?whitelisted=a,b,c format")
+	flag.Var(&source, "source", "source(s) to watch in [component-name]:http://host:port/path?whitelisted=a,b,c&podIdLabel=d&namespaceIdLabel=e&containerNameLabel=f format")
 	flag.Var(&dynamicSources, "dynamic-source",
-		`dynamic source(s) to watch in format: "[component-name]:http://:port/path?whitelisted=metric1,metric2". Dynamic sources are components (on the same node) discovered dynamically using the kubernetes api.`,
+		`dynamic source(s) to watch in format: "[component-name]:http://:port/path?whitelisted=metric1,metric2&podIdLabel=label1&namespaceIdLabel=label2&containerNameLabel=label3". Dynamic sources are components (on the same node) discovered dynamically using the kubernetes api.`,
 	)
 
 	defer glog.Flush()
@@ -150,7 +150,7 @@ func readAndPushDataToStackdriver(stackdriverService *v3.Service, gceConf *confi
 	glog.Infof("Running prometheus-to-sd, monitored target is %s %v:%v", sourceConfig.Component, sourceConfig.Host, sourceConfig.Port)
 	commonConfig := &config.CommonConfig{
 		GceConfig:     gceConf,
-		PodConfig:     &sourceConfig.PodConfig,
+		PodConfig:     sourceConfig.PodConfig,
 		ComponentName: sourceConfig.Component,
 	}
 	metricDescriptorCache := translator.NewMetricDescriptorCache(stackdriverService, commonConfig, sourceConfig.Component)

--- a/prometheus-to-sd/translator/translator_test.go
+++ b/prometheus-to-sd/translator/translator_test.go
@@ -53,10 +53,7 @@ var commonConfig = &config.CommonConfig{
 		Instance:      "kubernetes-master.c.test-proj.internal",
 		MetricsPrefix: "container.googleapis.com/master",
 	},
-	PodConfig: &config.PodConfig{
-		NamespaceId: "",
-		PodId:       "machine",
-	},
+	PodConfig:     config.NewPodConfig("machine", "", "", "", ""),
 	ComponentName: "testcomponent",
 }
 


### PR DESCRIPTION
Fixes #173.  See the issue for details.

```release-note
Adds the `container-name-label`, `pod-id-label`, `namespace-id-label` flags which allow prometheus labels to be used for SD resource labels.
```