### PR TITLE
[prometheus-to-sd] Add PodConfig in SourceConfig

### DIFF
--- a/prometheus-to-sd/config/common_config.go
+++ b/prometheus-to-sd/config/common_config.go
@@ -16,12 +16,6 @@ limitations under the License.
 
 package config
 
-// PodConfig describes pod in which current component is running.
-type PodConfig struct {
-	PodId       string
-	NamespaceId string
-}
-
 // CommonConfig contains all required information about environment in which
 // prometheus-to-sd running and which component is monitored.
 type CommonConfig struct {

--- a/prometheus-to-sd/config/source_config_test.go
+++ b/prometheus-to-sd/config/source_config_test.go
@@ -26,37 +26,44 @@ import (
 )
 
 func TestNewSourceConfig(t *testing.T) {
+	podConfig := PodConfig{
+		PodId:       "podId",
+		NamespaceId: "namespaceId",
+	}
 	correct := [...]struct {
 		component   string
 		host        string
 		port        string
 		path        string
 		whitelisted string
+		podConfig   PodConfig
 		output      SourceConfig
 	}{
-		{"testComponent", "localhost", "1234", defaultMetricsPath, "a,b,c,d",
+		{"testComponent", "localhost", "1234", defaultMetricsPath, "a,b,c,d", podConfig,
 			SourceConfig{
 				Component:   "testComponent",
 				Host:        "localhost",
 				Port:        1234,
 				Path:        defaultMetricsPath,
 				Whitelisted: []string{"a", "b", "c", "d"},
+				PodConfig:   podConfig,
 			},
 		},
 
-		{"testComponent", "localhost", "1234", "/status/prometheus", "",
+		{"testComponent", "localhost", "1234", "/status/prometheus", "", PodConfig{},
 			SourceConfig{
 				Component:   "testComponent",
 				Host:        "localhost",
 				Port:        1234,
 				Path:        "/status/prometheus",
 				Whitelisted: nil,
+				PodConfig:   PodConfig{},
 			},
 		},
 	}
 
 	for _, c := range correct {
-		res, err := newSourceConfig(c.component, c.host, c.port, c.path, c.whitelisted)
+		res, err := newSourceConfig(c.component, c.host, c.port, c.path, c.whitelisted, c.podConfig)
 		if assert.NoError(t, err) {
 			assert.Equal(t, c.output, *res)
 		}
@@ -64,6 +71,10 @@ func TestNewSourceConfig(t *testing.T) {
 }
 
 func TestParseSourceConfig(t *testing.T) {
+	podConfig := PodConfig{
+		PodId:       "podId",
+		NamespaceId: "namespaceId",
+	}
 	correct := [...]struct {
 		in     flags.Uri
 		output SourceConfig
@@ -84,6 +95,7 @@ func TestParseSourceConfig(t *testing.T) {
 				Port:        1234,
 				Path:        defaultMetricsPath,
 				Whitelisted: []string{"a", "b", "c", "d"},
+				PodConfig:   podConfig,
 			},
 		},
 		{
@@ -102,12 +114,13 @@ func TestParseSourceConfig(t *testing.T) {
 				Port:        1234,
 				Path:        "/status/prometheus",
 				Whitelisted: []string{"a", "b", "c", "d"},
+				PodConfig:   podConfig,
 			},
 		},
 	}
 
 	for _, c := range correct {
-		res, err := parseSourceConfig(c.in)
+		res, err := parseSourceConfig(c.in, podConfig)
 		if assert.NoError(t, err) {
 			assert.Equal(t, c.output, *res)
 		}
@@ -133,7 +146,7 @@ func TestParseSourceConfig(t *testing.T) {
 	}
 
 	for _, c := range incorrect {
-		_, err := parseSourceConfig(c)
+		_, err := parseSourceConfig(c, podConfig)
 		assert.Error(t, err)
 	}
 }


### PR DESCRIPTION
Until now all the sources were on the same pod, but as we prepare for changing prometheus to a daemon set, now it makes sense to include the pod configuration in the source configuration
This is a small refactoring for the upcoming daemon set changes