### PR TITLE
Added comparison with stackdriver-prometheus

### DIFF
--- a/prometheus-to-sd/README.md
+++ b/prometheus-to-sd/README.md
@@ -70,3 +70,9 @@ Note that prometheus labels used for the monitored resource are not included as 
 For example, if prom-to-sd scraped the prometheus metric: 
 `container_cpu_usage_seconds{d="my-namespace",e="abc123",f="my-app",g="production"} 1.02030405e+09`
 It would be displayed in stackdriver with the namespace, `my-namespace`, the pod id, `abc123`, and the container name, `my-app`.  The only stackdriver label for this metric would be `g="production"`.
+
+## Alternatives
+
+Google develops **prometheus-to-sd** primarily for Google Kubernetes Engine to collect metrics from system services in order to support Kubernetes users. We designed the tool to be lean when deployed as a sidecar in your pod. It's intended to support only the metrics the Kubernetes team at Google needs; you can use it to monitor your applications, but the feature set is limited.
+
+Google develops [**stackdriver-prometheus**](https://github.com/Stackdriver/stackdriver-prometheus) primarily for Stackdriver users and gives support to Stackdriver users. We designed the user experience to meet the expectations of Prometheus users and to make it easy to run with Prometheus server. stackdriver-prometheus is intended to monitor all your applications, Kubernetes and beyond.


### PR DESCRIPTION
The motivation is that the Stackdriver support team gets user requests to support prometheus-to-sd, even though we have an alternative that some of these users aren't aware of.