### PR TITLE
add support for other projects for external metrics

### DIFF
--- a/custom-metrics-stackdriver-adapter/Makefile
+++ b/custom-metrics-stackdriver-adapter/Makefile
@@ -1,4 +1,5 @@
 ARCH?=amd64
+GOOS?=linux
 OUT_DIR?=build
 PACKAGE=github.com/GoogleCloudPlatform/k8s-stackdriver/custom-metrics-stackdriver-adapter
 PREFIX?=staging-k8s.gcr.io
@@ -10,7 +11,7 @@ PKG := $(shell find pkg/* -type f)
 build: build/adapter
 
 build/adapter: adapter.go $(PKG)
-	CGO_ENABLED=0 GOARCH=$(ARCH) go build -a -o $(OUT_DIR)/$(ARCH)/adapter adapter.go
+	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(ARCH) go build -a -o $(OUT_DIR)/$(ARCH)/adapter adapter.go
 
 docker: build/adapter
 	docker build --pull -t ${PREFIX}/custom-metrics-stackdriver-adapter:$(TAG) .

--- a/custom-metrics-stackdriver-adapter/pkg/adapter/provider/translator.go
+++ b/custom-metrics-stackdriver-adapter/pkg/adapter/provider/translator.go
@@ -119,6 +119,11 @@ func (t *Translator) GetSDReqForNodes(nodeList *v1.NodeList, metricName string, 
 
 // GetExternalMetricRequest returns Stackdriver request for query for external metric.
 func (t *Translator) GetExternalMetricRequest(metricName string, metricKind string, metricSelector labels.Selector) (*stackdriver.ProjectsTimeSeriesListCall, error) {
+	metricProject, err := t.GetExternalMetricProject(metricSelector)
+	if err != nil {
+		return nil, err
+	}
+
 	filterForMetric := t.filterForMetric(metricName)
 	if metricSelector.Empty() {
 		return t.createListTimeseriesRequest(filterForMetric, metricKind), nil
@@ -127,7 +132,7 @@ func (t *Translator) GetExternalMetricRequest(metricName string, metricKind stri
 	if err != nil {
 		return nil, err
 	}
-	return t.createListTimeseriesRequest(joinFilters(filterForMetric, filterForSelector), metricKind), nil
+	return t.createListTimeseriesRequestProject(joinFilters(filterForMetric, filterForSelector), metricKind, metricProject), nil
 }
 
 // GetRespForSingleObject returns translates Stackdriver response to a Custom Metric associated with
@@ -236,6 +241,20 @@ func (t *Translator) GetMetricKind(metricName string) (string, error) {
 		return "", provider.NewNoSuchMetricError(metricName, err)
 	}
 	return response.MetricKind, nil
+}
+
+// If the metric has "resource.labels.project_id" as a selector, then use a different project
+func (t *Translator) GetExternalMetricProject(metricSelector labels.Selector) (string, error) {
+	requirements, selectable := metricSelector.Requirements()
+	if !selectable {
+		return "", apierr.NewBadRequest(fmt.Sprintf("Label selector is impossible to match: %s", metricSelector))
+	}
+	for _, req := range requirements {
+		if req.Key() == "resource.labels.project_id" {
+			return req.Values().List()[0], nil
+		}
+	}
+	return t.config.Project, nil
 }
 
 func getPodNames(list *v1.PodList) []string {
@@ -441,7 +460,11 @@ func (t *Translator) getMetricLabels(series *stackdriver.TimeSeries) map[string]
 }
 
 func (t *Translator) createListTimeseriesRequest(filter string, metricKind string) *stackdriver.ProjectsTimeSeriesListCall {
-	project := fmt.Sprintf("projects/%s", t.config.Project)
+	return t.createListTimeseriesRequestProject(filter, metricKind, t.config.Project)
+}
+
+func (t *Translator) createListTimeseriesRequestProject(filter string, metricKind string, metricProject string) *stackdriver.ProjectsTimeSeriesListCall {
+	project := fmt.Sprintf("projects/%s", metricProject)
 	endTime := t.clock.Now()
 	startTime := endTime.Add(-t.reqWindow)
 	// use "ALIGN_NEXT_OLDER" by default, i.e. for metricKind "GAUGE"

--- a/custom-metrics-stackdriver-adapter/pkg/adapter/provider/translator.go
+++ b/custom-metrics-stackdriver-adapter/pkg/adapter/provider/translator.go
@@ -243,7 +243,7 @@ func (t *Translator) GetMetricKind(metricName string) (string, error) {
 	return response.MetricKind, nil
 }
 
-// If the metric has "resource.labels.project_id" as a selector, then use a different project
+// GetExternalMetricProject If the metric has "resource.labels.project_id" as a selector, then use a different project
 func (t *Translator) GetExternalMetricProject(metricSelector labels.Selector) (string, error) {
 	requirements, selectable := metricSelector.Requirements()
 	if !selectable {

--- a/custom-metrics-stackdriver-adapter/pkg/adapter/provider/translator.go
+++ b/custom-metrics-stackdriver-adapter/pkg/adapter/provider/translator.go
@@ -248,7 +248,11 @@ func (t *Translator) GetExternalMetricProject(metricSelector labels.Selector) (s
 	requirements, _ := metricSelector.Requirements()
 	for _, req := range requirements {
 		if req.Key() == "resource.labels.project_id" {
-			return req.Values().List()[0], nil
+			if (req.Operator() == selection.Equals || req.Operator() == selection.DoubleEquals) {
+				return req.Values().List()[0], nil
+			} else {
+				return "", provider.NewLabelNotAllowedError(fmt.Sprintf("Project selector must use '=' or '==': You used %s", req.Operator()))
+			}
 		}
 	}
 	return t.config.Project, nil

--- a/custom-metrics-stackdriver-adapter/pkg/adapter/provider/translator.go
+++ b/custom-metrics-stackdriver-adapter/pkg/adapter/provider/translator.go
@@ -248,7 +248,7 @@ func (t *Translator) GetExternalMetricProject(metricSelector labels.Selector) (s
 	requirements, _ := metricSelector.Requirements()
 	for _, req := range requirements {
 		if req.Key() == "resource.labels.project_id" {
-			if (req.Operator() == selection.Equals || req.Operator() == selection.DoubleEquals) {
+			if req.Operator() == selection.Equals || req.Operator() == selection.DoubleEquals {
 				return req.Values().List()[0], nil
 			}
 			return "", provider.NewLabelNotAllowedError(fmt.Sprintf("Project selector must use '=' or '==': You used %s", req.Operator()))

--- a/custom-metrics-stackdriver-adapter/pkg/adapter/provider/translator.go
+++ b/custom-metrics-stackdriver-adapter/pkg/adapter/provider/translator.go
@@ -245,10 +245,7 @@ func (t *Translator) GetMetricKind(metricName string) (string, error) {
 
 // GetExternalMetricProject If the metric has "resource.labels.project_id" as a selector, then use a different project
 func (t *Translator) GetExternalMetricProject(metricSelector labels.Selector) (string, error) {
-	requirements, selectable := metricSelector.Requirements()
-	if !selectable {
-		return "", apierr.NewBadRequest(fmt.Sprintf("Label selector is impossible to match: %s", metricSelector))
-	}
+	requirements, _ := metricSelector.Requirements()
 	for _, req := range requirements {
 		if req.Key() == "resource.labels.project_id" {
 			return req.Values().List()[0], nil

--- a/custom-metrics-stackdriver-adapter/pkg/adapter/provider/translator.go
+++ b/custom-metrics-stackdriver-adapter/pkg/adapter/provider/translator.go
@@ -250,9 +250,8 @@ func (t *Translator) GetExternalMetricProject(metricSelector labels.Selector) (s
 		if req.Key() == "resource.labels.project_id" {
 			if (req.Operator() == selection.Equals || req.Operator() == selection.DoubleEquals) {
 				return req.Values().List()[0], nil
-			} else {
-				return "", provider.NewLabelNotAllowedError(fmt.Sprintf("Project selector must use '=' or '==': You used %s", req.Operator()))
 			}
+			return "", provider.NewLabelNotAllowedError(fmt.Sprintf("Project selector must use '=' or '==': You used %s", req.Operator()))
 		}
 	}
 	return t.config.Project, nil

--- a/custom-metrics-stackdriver-adapter/pkg/adapter/server/start.go
+++ b/custom-metrics-stackdriver-adapter/pkg/adapter/server/start.go
@@ -116,7 +116,7 @@ func (o sampleAdapterServerOptions) RunCustomMetricsAdapterServer(stopCh <-chan 
 		return fmt.Errorf("unable to construct dynamic mapper: %v", err)
 	}
 
-	tokenSource, err := google.DefaultTokenSource(oauth2.NoContext, "")
+	tokenSource, err := google.DefaultTokenSource(oauth2.NoContext, "https://www.googleapis.com/auth/monitoring.read")
 	if err != nil {
 		return fmt.Errorf("unable to use default token source: %v", err)
 	}


### PR DESCRIPTION
Addresses https://github.com/GoogleCloudPlatform/k8s-stackdriver/issues/205

I tried to keep my changes as minimal as possible as I don't really have the bandwidth or expertise to do a large refactor. This has been tested in my environment to maintain existing functionality, as well as access to metrics in other projects. Adding scope was necessary to allow a service account to work, rather than GCE creds.

I would be happy to contribute documentation if this PR's code is deemed mergable.

Example spec:
```
apiVersion: autoscaling/v2beta1
kind: HorizontalPodAutoscaler
metadata:
  name: dummy
  namespace: default
spec:
  scaleTargetRef:
    apiVersion: apps/v1beta1
    kind: Deployment
    name: dummy
  minReplicas: 1
  maxReplicas: 5
  metrics:
  - external:
      metricName: pubsub.googleapis.com|subscription|num_undelivered_messages
      metricSelector:
        matchLabels:
          resource.labels.subscription_id: super-awesome-sub
          resource.labels.project_id: other-project
      targetAverageValue: "2"
    type: External
```

Note: Access to other projects requires running the stackdriver adapter with a service account (recommended), or adding permissions to the default GCE creds (not advised).