### PR TITLE
add ability to optionally downcase all metric names, in case metric names do not conform to stackdriver naming conventions

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -32,6 +32,7 @@ dnsmasq-poll-interval-ms
 dnsmasq-port
 do-not-merge-milestones
 dont-require-e2e-label
+downcase-metric-names
 dry-run
 dump-nginx-configuration
 dynamic-source

--- a/prometheus-to-sd/config/common_config.go
+++ b/prometheus-to-sd/config/common_config.go
@@ -70,8 +70,9 @@ func (p *podConfigImpl) GetPodInfo(labels []*dto.LabelPair) (containerName, podI
 // CommonConfig contains all required information about environment in which
 // prometheus-to-sd running and which component is monitored.
 type CommonConfig struct {
-	GceConfig         *GceConfig
-	PodConfig         PodConfig
-	ComponentName     string
-	OmitComponentName bool
+	GceConfig           *GceConfig
+	PodConfig           PodConfig
+	ComponentName       string
+	OmitComponentName   bool
+	DowncaseMetricNames bool
 }

--- a/prometheus-to-sd/main.go
+++ b/prometheus-to-sd/main.go
@@ -61,6 +61,8 @@ var (
 		"The interval between metric scrapes. If there are multiple scrapes between two exports, the last present value is exported, even when missing from last scraping.")
 	exportInterval = flag.Duration("export-interval", 60*time.Second,
 		"The interval between metric exports. Can't be lower than --scrape-interval.")
+	downcaseMetricNames = flag.Bool("downcase-metric-names", false,
+		"If enabled, will downcase all metric names.")
 )
 
 func main() {
@@ -130,10 +132,11 @@ func getSourceConfigs(gceConfig *config.GceConfig) []config.SourceConfig {
 func readAndPushDataToStackdriver(stackdriverService *v3.Service, gceConf *config.GceConfig, sourceConfig config.SourceConfig) {
 	glog.Infof("Running prometheus-to-sd, monitored target is %s %v:%v", sourceConfig.Component, sourceConfig.Host, sourceConfig.Port)
 	commonConfig := &config.CommonConfig{
-		GceConfig:         gceConf,
-		PodConfig:         sourceConfig.PodConfig,
-		ComponentName:     sourceConfig.Component,
-		OmitComponentName: *omitComponentName,
+		GceConfig:           gceConf,
+		PodConfig:           sourceConfig.PodConfig,
+		ComponentName:       sourceConfig.Component,
+		OmitComponentName:   *omitComponentName,
+		DowncaseMetricNames: *downcaseMetricNames,
 	}
 	metricDescriptorCache := translator.NewMetricDescriptorCache(stackdriverService, commonConfig, sourceConfig.Component)
 	signal := time.After(0)

--- a/prometheus-to-sd/translator/prometheus.go
+++ b/prometheus-to-sd/translator/prometheus.go
@@ -74,6 +74,9 @@ func (p *PrometheusResponse) Build(commonConfig *config.CommonConfig, sourceConf
 	if commonConfig.OmitComponentName {
 		metrics = OmitComponentName(metrics, sourceConfig.Component)
 	}
+	if commonConfig.DowncaseMetricNames {
+		metrics = DowncaseMetricNames(metrics)
+	}
 	if strings.HasPrefix(commonConfig.GceConfig.MetricsPrefix, customMetricsPrefix) {
 		metricDescriptorCache.UpdateMetricDescriptors(metrics, sourceConfig.Whitelisted)
 	} else {

--- a/prometheus-to-sd/translator/translator.go
+++ b/prometheus-to-sd/translator/translator.go
@@ -111,6 +111,17 @@ func OmitComponentName(metricFamilies map[string]*dto.MetricFamily, componentNam
 	return result
 }
 
+// DowncaseMetricNames downcases metric names.
+func DowncaseMetricNames(metricFamilies map[string]*dto.MetricFamily) map[string]*dto.MetricFamily {
+	result := make(map[string]*dto.MetricFamily)
+	for metricName, metricFamily := range metricFamilies {
+		newMetricName := strings.ToLower(metricName)
+		metricFamily.Name = &newMetricName
+		result[newMetricName] = metricFamily
+	}
+	return result
+}
+
 func getStartTime(metrics map[string]*dto.MetricFamily) time.Time {
 	// For cumulative metrics we need to know process start time.
 	// If the process start time is not specified, assuming it's

--- a/prometheus-to-sd/translator/translator_test.go
+++ b/prometheus-to-sd/translator/translator_test.go
@@ -550,3 +550,43 @@ func stringPtr(val string) *string {
 	ptr := val
 	return &ptr
 }
+
+func TestDowncaseMetricNames(t *testing.T) {
+	var normalMetric1 = "metric1"
+	var metricWithComponentPrefix = "testComponent_metric"
+	var metricWithIncorrectComponentPrefix = "testComponentMetric"
+
+	var metricFamiliesForWhitelistTest = map[string]*dto.MetricFamily{
+		normalMetric1: {
+			Name: stringPtr(normalMetric1),
+		},
+		metricWithComponentPrefix: {
+			Name: stringPtr(metricWithComponentPrefix),
+		},
+		metricWithIncorrectComponentPrefix: {
+			Name: stringPtr(metricWithIncorrectComponentPrefix),
+		},
+	}
+	tests := []struct {
+		name         string
+		inputMetrics map[string]*dto.MetricFamily
+	}{
+		{"Test downcase names",
+			metricFamiliesForWhitelistTest,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DowncaseMetricNames(tt.inputMetrics)
+			for k, v := range got {
+				if k != strings.ToLower(k) {
+					t.Errorf("metric name key is not properly downcased, got %s, want %s", k, strings.ToLower(k))
+				}
+
+				if v.GetName() != strings.ToLower(v.GetName()) {
+					t.Errorf("metric name is not properly downcased, got %s, want %s", v.GetName(), strings.ToLower(v.GetName()))
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds the ability to optionally downcase metric names (if it is so desired). It can be enabled via a command line flag and is defaulted to false. This is possibly desirable if stackdriver metric naming conventions are not in line with the actual metric names we want to import to stackdriver.