### PR TITLE
add partial summary support for metric imports

### DIFF
--- a/prometheus-to-sd/main.go
+++ b/prometheus-to-sd/main.go
@@ -182,6 +182,6 @@ func readAndPushDataToStackdriver(stackdriverService *v3.Service, gceConf *confi
 			glog.V(2).Infof("Error while getting Prometheus metrics %v for component %v", err, sourceConfig.Component)
 			continue
 		}
-		timeSeriesBuilder.Update(metrics)
+		timeSeriesBuilder.Update(metrics, time.Now())
 	}
 }

--- a/prometheus-to-sd/translator/prometheus.go
+++ b/prometheus-to-sd/translator/prometheus.go
@@ -77,6 +77,9 @@ func (p *PrometheusResponse) Build(commonConfig *config.CommonConfig, sourceConf
 	if commonConfig.DowncaseMetricNames {
 		metrics = DowncaseMetricNames(metrics)
 	}
+	// Convert summary metrics into metric family types we can easily import, since summary types
+	// map to multiple stackdriver metrics.
+	metrics = FlattenSummaryMetricFamilies(metrics)
 	if strings.HasPrefix(commonConfig.GceConfig.MetricsPrefix, customMetricsPrefix) {
 		metricDescriptorCache.UpdateMetricDescriptors(metrics, sourceConfig.Whitelisted)
 	} else {

--- a/prometheus-to-sd/translator/translator.go
+++ b/prometheus-to-sd/translator/translator.go
@@ -66,8 +66,8 @@ func NewTimeSeriesBuilder(commonConfig *config.CommonConfig, sourceConfig *confi
 }
 
 // Update updates the internal state with current batch.
-func (t *TimeSeriesBuilder) Update(batch *PrometheusResponse) {
-	t.batch = &batchWithTimestamp{batch, time.Now()}
+func (t *TimeSeriesBuilder) Update(batch *PrometheusResponse, timestamp time.Time) {
+	t.batch = &batchWithTimestamp{batch, timestamp}
 }
 
 // Build returns a new TimeSeries array and restarts the internal state.

--- a/prometheus-to-sd/translator/translator.go
+++ b/prometheus-to-sd/translator/translator.go
@@ -130,8 +130,7 @@ func FlattenSummaryMetricFamilies(metricFamilies map[string]*dto.MetricFamily) m
 		switch family.GetType() {
 		case dto.MetricType_SUMMARY:
 			if len(family.Metric) < 1 {
-				glog.V(2).Infof(
-					"Summary metric %v does not have metric data associated, ignoring", family.Name)
+				glog.V(2).Infof("Summary metric %v does not have metric data associated, ignoring", family.Name)
 				continue
 			}
 			result[metricName+"_sum"] = sumMetricFromSummary(family.GetName(), family.Metric)

--- a/prometheus-to-sd/translator/translator.go
+++ b/prometheus-to-sd/translator/translator.go
@@ -122,6 +122,72 @@ func DowncaseMetricNames(metricFamilies map[string]*dto.MetricFamily) map[string
 	return result
 }
 
+// FlattenSummaryMetricFamilies flattens summary metric families into two counter metrics,
+// one for the running sum and count, respectively
+func FlattenSummaryMetricFamilies(metricFamilies map[string]*dto.MetricFamily) map[string]*dto.MetricFamily {
+	result := make(map[string]*dto.MetricFamily)
+	for metricName, family := range metricFamilies {
+		switch family.GetType() {
+		case dto.MetricType_SUMMARY:
+			if len(family.Metric) < 1 {
+				glog.V(2).Infof(
+					"Summary metric %v does not have metric data associated, ignoring", family.Name)
+				continue
+			}
+			result[metricName+"_sum"] = sumMetricFromSummary(family.GetName(), family.Metric)
+			result[metricName+"_count"] = countMetricFromSummary(family.GetName(), family.Metric)
+		default:
+			result[metricName] = family
+		}
+	}
+	return result
+}
+
+// sumMetricFromSummary manipulates a Summary to extract out a specific sum MetricType_COUNTER metric
+func sumMetricFromSummary(name string, metrics []*dto.Metric) *dto.MetricFamily {
+	n := name + "_sum"
+	t := dto.MetricType_COUNTER
+	newMetrics := make([]*dto.Metric, 0, len(metrics))
+	for _, m := range metrics {
+		s := m.Summary.GetSampleSum()
+		newMetric := &dto.Metric{
+			Label: m.Label,
+			Counter: &dto.Counter{
+				Value: &s,
+			},
+		}
+		newMetrics = append(newMetrics, newMetric)
+	}
+	return &dto.MetricFamily{
+		Type:   &t,
+		Name:   &n,
+		Metric: newMetrics,
+	}
+}
+
+// countMetricFromSummary manipulates a Summary to extract out a specific count MetricType_COUNTER metric
+func countMetricFromSummary(name string, metrics []*dto.Metric) *dto.MetricFamily {
+	n := name + "_count"
+	t := dto.MetricType_COUNTER
+
+	newMetrics := make([]*dto.Metric, 0, len(metrics))
+	for _, m := range metrics {
+		c := float64(m.Summary.GetSampleCount())
+		newMetric := &dto.Metric{
+			Label: m.Label,
+			Counter: &dto.Counter{
+				Value: &c,
+			},
+		}
+		newMetrics = append(newMetrics, newMetric)
+	}
+	return &dto.MetricFamily{
+		Type:   &t,
+		Name:   &n,
+		Metric: newMetrics,
+	}
+}
+
 func getStartTime(metrics map[string]*dto.MetricFamily) time.Time {
 	// For cumulative metrics we need to know process start time.
 	// If the process start time is not specified, assuming it's
@@ -163,7 +229,7 @@ func translateFamily(config *config.CommonConfig,
 	glog.V(3).Infof("Translating metric family %v from component %v", family.GetName(), config.ComponentName)
 	var ts []*v3.TimeSeries
 	if _, found := supportedMetricTypes[family.GetType()]; !found {
-		return ts, fmt.Errorf("Metric type %v of family %s not supported", family.GetType(), family.GetName())
+		return ts, fmt.Errorf("metric type %v of family %s not supported", family.GetType(), family.GetName())
 	}
 	for _, metric := range family.GetMetric() {
 		t := translateOne(config, family.GetName(), family.GetType(), metric, startTime, timestamp, cache)


### PR DESCRIPTION
This PR adds partial summary metric importing ability for prom-to-sd (partially addressing #196). There are some important caveats, however:

1. Quantile metric data is disregarded, mostly because [it doesn't make a whole lot of sense to aggregate over the quantile metric data](https://prometheus.io/docs/practices/histograms/#errors-of-quantile-estimation). Aggregating across this data will give you averages. You will lose quantile information.
2. If you want to import summary metric information, you must first ensure that the metric you are summing does not have negative values ([this is despite the fact that prometheus documentation expressly allows for this possibility](https://prometheus.io/docs/practices/histograms/#count-and-sum-of-observations)). Unfortunately, this must be the case due to data type impedance mismatching between prometheus and stackdriver. So if you want to use this feature, you should first ensure your metric is measuring positive values. With things like latency measurements, this shouldn't be a problem. 
3. If you are whitelisting metrics, then you must whitelist the summary metric name + '_sum' as well as the summary metric name + "_count". This is due to the fact that this metric type maps to multiple stackdriver metrics. 