### PR TITLE
prometheus-to-sd-kube-state-metrics: bump example version number

### DIFF
--- a/prometheus-to-sd/kubernetes/prometheus-to-sd-kube-state-metrics.yaml
+++ b/prometheus-to-sd/kubernetes/prometheus-to-sd-kube-state-metrics.yaml
@@ -24,7 +24,7 @@ spec:
         memory: 300Mi
         cpu: 200m
   - name: prometheus-to-sd
-    image: gcr.io/google-containers/prometheus-to-sd:v0.3.2
+    image: gcr.io/google-containers/prometheus-to-sd:v0.4.1
     ports:
       - name: profiler
         containerPort: 6060


### PR DESCRIPTION
previous version did not export metrics and did not throw any error.