### PR TITLE
Bump version of prometheus-to-sd.

### DIFF
--- a/prometheus-to-sd/Makefile
+++ b/prometheus-to-sd/Makefile
@@ -16,7 +16,7 @@ all: build
 
 ENVVAR = GOOS=linux GOARCH=amd64 CGO_ENABLED=0
 PREFIX = staging-k8s.gcr.io
-TAG = v0.4.1
+TAG = v0.4.2
 
 build:
 	$(ENVVAR) go build -a -o monitor


### PR DESCRIPTION
There is only one undirect change in base image. See https://github.com/GoogleContainerTools/distroless/pull/296.
Without it image doesn't work in containerd env.