### PR TITLE
Do not skip whole stats population for single nil stats.

### DIFF
--- a/kubelet-to-gcm/monitor/kubelet/translate.go
+++ b/kubelet-to-gcm/monitor/kubelet/translate.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/golang/glog"
 	v3 "google.golang.org/api/monitoring/v3"
 	"k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/stats"
 
@@ -217,27 +218,35 @@ func (t *Translator) translateContainers(pods []stats.PodStats) ([]*v3.TimeSerie
 			// Memory stats.
 			memTS, err := translateMemory(container.Memory, tsFactory, container.StartTime.Time)
 			if err != nil {
-				return nil, err
+				glog.Warningf("Failed to translate memory stats for container %q in pod %q(%q): %v",
+					containerName, podID, namespace, err)
+				continue
 			}
 			containerSeries = append(containerSeries, memTS...)
 
 			// File-system stats.
 			rootfsTS, err := translateFS("/", container.Rootfs, tsFactory, container.StartTime.Time)
 			if err != nil {
-				return nil, err
+				glog.Warningf("Failed to translate rootfs stats for container %q in pod %q(%q): %v",
+					containerName, podID, namespace, err)
+				continue
 			}
 			containerSeries = append(containerSeries, rootfsTS...)
 
 			logfsTS, err := translateFS("logs", container.Logs, tsFactory, container.StartTime.Time)
 			if err != nil {
-				return nil, err
+				glog.Warningf("Failed to translate log stats for container %q in pod %q(%q): %v",
+					containerName, podID, namespace, err)
+				continue
 			}
 			containerSeries = append(containerSeries, logfsTS...)
 
 			// CPU stats.
 			cpuTS, err := translateCPU(container.CPU, tsFactory, container.StartTime.Time)
 			if err != nil {
-				return nil, err
+				glog.Warningf("Failed to translate cpu stats for container %q in pod %q(%q): %v",
+					containerName, podID, namespace, err)
+				continue
 			}
 			containerSeries = append(containerSeries, cpuTS...)
 

--- a/kubelet-to-gcm/monitor/kubelet/translate_test.go
+++ b/kubelet-to-gcm/monitor/kubelet/translate_test.go
@@ -203,6 +203,14 @@ func TestTranslator(t *testing.T) {
 func TestTranslateContainers(t *testing.T) {
 	aliceContainer := *getContainerStats(false)
 	bobContainer := *getContainerStats(false)
+	noMemStatsContainer := *getContainerStats(false)
+	noMemStatsContainer.Memory = nil
+	noCPUStatsContainer := *getContainerStats(false)
+	noCPUStatsContainer.CPU = nil
+	noLogStatsContainer := *getContainerStats(false)
+	noLogStatsContainer.Logs = nil
+	noRootfsStatsContainer := *getContainerStats(false)
+	noRootfsStatsContainer.Rootfs = nil
 	tsPerContainer := 11
 	testCases := []struct {
 		name            string
@@ -263,6 +271,19 @@ func TestTranslateContainers(t *testing.T) {
 			pods: []stats.PodStats{
 				getPodStats(aliceContainer),
 				getPodStats(aliceContainer),
+			},
+		},
+		{
+			name:            "single pod with empty stats container",
+			ExpectedTSCount: tsPerContainer * 1,
+			pods: []stats.PodStats{
+				getPodStats(
+					aliceContainer,
+					noMemStatsContainer,
+					noCPUStatsContainer,
+					noLogStatsContainer,
+					noRootfsStatsContainer,
+				),
 			},
 		},
 	}


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/k8s-stackdriver/issues/233.

Summary stats for CRI integration can return nil fields for terminated containers, we should not skip the whole stats population for a single nil container stats.