### PR TITLE
Collect system container stats.

### DIFF
--- a/hack/verify-flags/exceptions.txt
+++ b/hack/verify-flags/exceptions.txt
@@ -32,10 +32,10 @@ custom-metrics-stackdriver-adapter/pkg/adapter/provider/translator_test.go:	req3
 event-exporter/sinks/stackdriver/monitored_resource_factory.go:	podName       = "pod_name"
 kubelet-to-gcm/monitor/controller/translator.go:		"namespace_id":   "",
 kubelet-to-gcm/monitor/controller/translator.go:		"pod_id":         "machine",
-kubelet-to-gcm/monitor/kubelet/translate.go:				"namespace_id":   namespace,
-kubelet-to-gcm/monitor/kubelet/translate.go:				"pod_id":         podID,
 kubelet-to-gcm/monitor/kubelet/translate.go:		"namespace_id":   "",
+kubelet-to-gcm/monitor/kubelet/translate.go:		"namespace_id":   namespace,
 kubelet-to-gcm/monitor/kubelet/translate.go:		"pod_id":         "machine",
+kubelet-to-gcm/monitor/kubelet/translate.go:		"pod_id":         podID,
 prometheus-to-sd/README.md:the prometheus-to-sd. Values of the `namespace_id` and `pod_id` can be passed to
 prometheus-to-sd/translator/metrics.go:		[]string{"component_name", "metric_name"},
 prometheus-to-sd/translator/translator.go:				"namespace_id":   namespace,

--- a/kubelet-to-gcm/monitor/kubelet/translate_test.go
+++ b/kubelet-to-gcm/monitor/kubelet/translate_test.go
@@ -64,10 +64,6 @@ const (
                     "usageCoreNanoSeconds": 10000000000,
                     "usageNanoCores": 1000000000
                 },
-                "logs": {
-                    "availableBytes": 5000,
-                    "capacityBytes": 10000
-                },
                 "memory": {
                     "majorPageFaults": 5,
                     "pageFaults": 10,
@@ -77,11 +73,7 @@ const (
                     "workingSetBytes": 2700
                 },
                 "name": "misc",
-                "rootfs": {
-                    "availableBytes": 6000,
-                    "capacityBytes": 10000
-                },
-                "startTime": "2016-06-08T00:26:41Z",
+		"startTime": "2016-06-08T00:26:41Z",
                 "userDefinedMetrics": null
             }
         ]
@@ -178,7 +170,7 @@ func TestTranslator(t *testing.T) {
 			InstanceID:      "this-instance",
 			Resolution:      time.Second * time.Duration(10),
 			Summary:         summaryJSON,
-			ExpectedTSCount: 28,
+			ExpectedTSCount: 34,
 		},
 	}
 


### PR DESCRIPTION
Support collecting stats for system containers. These stats are very useful, especially the `kubelet` one and `runtime` one.

An example:
```json
"systemContainers": [
    {
     "name": "kubelet",
     "startTime": "2018-12-19T10:50:26Z",
     "cpu": {
      "time": "2019-03-08T08:53:41Z",
      "usageNanoCores": 33617729,
      "usageCoreNanoSeconds": 298544078034837
     },
     "memory": {
      "time": "2019-03-08T08:53:41Z",
      "usageBytes": 245764096,
      "workingSetBytes": 245534720,
      "rssBytes": 88256512,
      "pageFaults": 3384427256,
      "majorPageFaults": 2413
     },
     "userDefinedMetrics": null
    },
    {
     "name": "runtime",
     "startTime": "2018-12-19T10:50:26Z",
     "cpu": {
      "time": "2019-03-08T08:53:36Z",
      "usageNanoCores": 429159480,
      "usageCoreNanoSeconds": 1172508115040995
     },
     "memory": {
      "time": "2019-03-08T08:53:36Z",
      "usageBytes": 685658112,
      "workingSetBytes": 612192256,
      "rssBytes": 80506880,
      "pageFaults": 984220197,
      "majorPageFaults": 26363
     },
     "userDefinedMetrics": null
    },
    {
     "name": "pods",
     "startTime": "2018-12-19T10:50:27Z",
     "cpu": {
      "time": "2019-03-08T08:53:37Z",
      "usageNanoCores": 389319890,
      "usageCoreNanoSeconds": 3692700385625213
     },
     "memory": {
      "time": "2019-03-08T08:53:37Z",
      "availableBytes": 31637762048,
      "usageBytes": 47275667456,
      "workingSetBytes": 18169200640,
      "rssBytes": 481611776,
      "pageFaults": 0,
      "majorPageFaults": 0
     },
     "userDefinedMetrics": null
    }
   ],
```
Signed-off-by: Lantao Liu <lantaol@google.com>