### PR TITLE
Rebase kubelet-to-gcm to distroless

### DIFF
--- a/kubelet-to-gcm/Dockerfile
+++ b/kubelet-to-gcm/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM scratch
+FROM gcr.io/distroless/static:latest
 
 COPY build/monitor /
 


### PR DESCRIPTION
This is part of the effort described in kep kubernetes/enhancements#900