### PR TITLE
Update scaler.sh

### DIFF
--- a/fluentd-gcp-scaler/scaler.sh
+++ b/fluentd-gcp-scaler/scaler.sh
@@ -23,7 +23,7 @@ log() {
 apply_scaling() {
   # This is assuming there is a ScalingPolicy installed in the cluster.
   # See https://github.com/justinsb/scaler for more details.
-  if ! kubectl get scalingpolicies -n ${NAMESPACE} ${SCALING_POLICY} &> /dev/null
+  if ! kubectl get scalingpolicies -n ${NAMESPACE} ${SCALING_POLICY} >/dev/null 2>&1
   then
     return
   fi

--- a/fluentd-gcp-scaler/scaler.sh
+++ b/fluentd-gcp-scaler/scaler.sh
@@ -23,7 +23,7 @@ log() {
 apply_scaling() {
   # This is assuming there is a ScalingPolicy installed in the cluster.
   # See https://github.com/justinsb/scaler for more details.
-  if ! kubectl get scalingpolicies -n ${NAMESPACE} ${SCALING_POLICY} 2> /dev/null
+  if ! kubectl get scalingpolicies -n ${NAMESPACE} ${SCALING_POLICY} &> /dev/null
   then
     return
   fi


### PR DESCRIPTION
Redirecting only stderr to /dev/null will spam the stackdriver logs with the acutal output of the "kubectl get" command. Both stdout and stderr should be redirected.