### PR TITLE
Bump Kubelet to GCM and Event Exporter versions

### DIFF
--- a/event-exporter/Makefile
+++ b/event-exporter/Makefile
@@ -19,7 +19,7 @@ BINARY_NAME = event-exporter
 
 PREFIX = staging-k8s.gcr.io
 IMAGE_NAME = event-exporter
-TAG = v0.2.4
+TAG = v0.2.5
 
 build:
 	${ENVVAR} go build -a -o ${BINARY_NAME}

--- a/kubelet-to-gcm/Makefile
+++ b/kubelet-to-gcm/Makefile
@@ -15,7 +15,7 @@
 OUT_DIR = build
 PACKAGE = github.com/GoogleCloudPlatform/k8s-stackdriver/kubelet-to-gcm
 PREFIX = staging-k8s.gcr.io
-TAG = 1.2.10
+TAG = 1.2.11
 
 # Rules for building the real image for deployment to gcr.io
 


### PR DESCRIPTION
Bump versions for new release, which builds images from distroless.