### PR TITLE
Add filtering by prometheus label to prom-to-sd

### DIFF
--- a/prometheus-to-sd/README.md
+++ b/prometheus-to-sd/README.md
@@ -1,5 +1,4 @@
 # Overview
-
 prometheus-to-sd is a simple component that can scrape metrics stored in
 [prometheus text format](https://prometheus.io/docs/instrumenting/exposition_formats/)
 from one or multiple components and push them to the Stackdriver. Main requirement:
@@ -13,9 +12,13 @@ Look at the following link: https://gcr.io/google-containers/prometheus-to-sd an
 
 For scraping metrics from the component it's name, host, port and metrics should passed
 through the flag `source` in the next format:
-`component-name:http://host:port?whitelisted=a,b,c`. If whitelisted part is
-omitted, then all metrics that are scraped from the component will be pushed
-to the Stackdriver, unless flag `auto-whitelist-metrics=true` was passed.
+`component-name:http://host:port?whitelisted=a,b,c&whitelistedLabels=podIdLabel:podId1,podId2|containerLabelName:containerName1,containerName2`.
+If whitelisted part is omitted, then all metrics that are scraped from the component will be pushed
+to the Stackdriver, unless flag `auto-whitelist-metrics=true` was passed. If whitelistedLabels part is omitted,
+then all metrics that are scraped from the component will be pushed to Stackdriver.
+Otherwise, only metrics with labels with all label values included in the whitelistedLabel values will be pushed.
+In the above example, only metrics with podIdLabel in [podId1, podId2] and containerLabelName in [containerName1, containerName2] will be pushed.
+Valid labels to filter against are containerLabelName, namespaceIdLabel, and podIdLabel.
 
 ## Custom metrics
 

--- a/prometheus-to-sd/config/dynamic_source.go
+++ b/prometheus-to-sd/config/dynamic_source.go
@@ -9,7 +9,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-stackdriver/prometheus-to-sd/flags"
 	"github.com/golang/glog"
 	core "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
@@ -111,5 +111,9 @@ func mapToSourceConfig(componentName string, url url.URL, ip string, podId, name
 		return nil, err
 	}
 	podConfig := NewPodConfig(podId, namespaceId, podIdLabel, namespaceIdLabel, containerNamelabel)
-	return newSourceConfig(componentName, protocol, ip, port, url.Path, *auth, whitelisted, metricsPrefix, podConfig)
+	whitelistedLabelsMap, err := parseWhitelistedLabels(url.Query().Get("whitelistedLabels"))
+	if err != nil {
+		return nil, err
+	}
+	return newSourceConfig(componentName, protocol, ip, port, url.Path, *auth, whitelisted, metricsPrefix, podConfig, whitelistedLabelsMap)
 }

--- a/prometheus-to-sd/config/source_config.go
+++ b/prometheus-to-sd/config/source_config.go
@@ -29,21 +29,24 @@ import (
 
 // SourceConfig contains data specific for scraping one component.
 type SourceConfig struct {
-	Component     string
-	Protocol      string
-	Host          string
-	Port          uint
-	Path          string
-	AuthConfig    AuthConfig
-	Whitelisted   []string
-	PodConfig     PodConfig
-	MetricsPrefix string
+	Component            string
+	Protocol             string
+	Host                 string
+	Port                 uint
+	Path                 string
+	AuthConfig           AuthConfig
+	Whitelisted          []string
+	WhitelistedLabelsMap map[string]map[string]bool
+	PodConfig            PodConfig
+	MetricsPrefix        string
 }
 
 const defaultMetricsPath = "/metrics"
 
+var validWhitelistedLabels = map[string]bool{"containerNameLabel": true, "namespaceIdLabel": true, "podIdLabel": true}
+
 // newSourceConfig creates a new SourceConfig based on string representation of fields.
-func newSourceConfig(component, protocol, host, port, path string, auth AuthConfig, whitelisted, metricsPrefix string, podConfig PodConfig) (*SourceConfig, error) {
+func newSourceConfig(component, protocol, host, port, path string, auth AuthConfig, whitelisted, metricsPrefix string, podConfig PodConfig, whitelistedLabelsMap map[string]map[string]bool) (*SourceConfig, error) {
 	if port == "" {
 		return nil, fmt.Errorf("No port provided.")
 	}
@@ -70,15 +73,16 @@ func newSourceConfig(component, protocol, host, port, path string, auth AuthConf
 	}
 
 	return &SourceConfig{
-		Component:     component,
-		Protocol:      protocol,
-		Host:          host,
-		Port:          uint(portNum),
-		Path:          path,
-		AuthConfig:    auth,
-		Whitelisted:   whitelistedList,
-		PodConfig:     podConfig,
-		MetricsPrefix: metricsPrefix,
+		Component:            component,
+		Protocol:             protocol,
+		Host:                 host,
+		Port:                 uint(portNum),
+		Path:                 path,
+		AuthConfig:           auth,
+		Whitelisted:          whitelistedList,
+		WhitelistedLabelsMap: whitelistedLabelsMap,
+		PodConfig:            podConfig,
+		MetricsPrefix:        metricsPrefix,
 	}, nil
 }
 
@@ -104,7 +108,11 @@ func parseSourceConfig(uri flags.Uri, podId, namespaceId string) (*SourceConfig,
 	}
 	podConfig := NewPodConfig(podId, namespaceId, podIdLabel, namespaceIdLabel, containerNamelabel)
 
-	return newSourceConfig(component, protocol, host, port, path, *auth, whitelisted, metricsPrefix, podConfig)
+	whitelistedLabelsMap, err := parseWhitelistedLabels(values.Get("whitelistedLabels"))
+	if err != nil {
+		return nil, err
+	}
+	return newSourceConfig(component, protocol, host, port, path, *auth, whitelisted, metricsPrefix, podConfig, whitelistedLabelsMap)
 }
 
 // UpdateWhitelistedMetrics sets passed list as a list of whitelisted metrics.
@@ -126,4 +134,31 @@ func SourceConfigsFromFlags(source flags.Uris, podId *string, namespaceId *strin
 		}
 	}
 	return sourceConfigs
+}
+
+// parseWhitelistedLabels extracts the labels and their corresponding whitelisted values that will be filtered for.
+func parseWhitelistedLabels(whitelistedLabels string) (map[string]map[string]bool, error) {
+	// whitelistedLabels  is of the format whitelistedLabel1:val11,val12,etc.|whitelistedLabel2:val21
+	labelsMap := make(map[string]map[string]bool)
+	// URL.Query().Get() will return "" if whitelistedLabels is not specified
+	if whitelistedLabels == "" {
+		return labelsMap, nil
+	}
+	labelVals := strings.Split(whitelistedLabels, "|")
+	for _, labelVal := range labelVals {
+		labelAndValueParts := strings.Split(labelVal, ":")
+		if len(labelAndValueParts) != 2 {
+			return nil, fmt.Errorf("Incorrectly formatted whitelisted label and values: %v", labelVal)
+		}
+		labelKey := labelAndValueParts[0]
+		if validWhitelistedLabels[labelKey] {
+			labelsMap[labelKey] = make(map[string]bool)
+			for _, val := range strings.Split(labelAndValueParts[1], ",") {
+				labelsMap[labelAndValueParts[0]][val] = true
+			}
+		} else {
+			return nil, fmt.Errorf("Filtering against label %v is unsupported. Only containerNameLabel, namespaceIdLabel, and podIdLabel are supported.", labelKey)
+		}
+	}
+	return labelsMap, nil
 }


### PR DESCRIPTION
In order to allow for exporting by container name, or other label values, this PR adds the ability to filter by prometheus label values before exporting to stackdriver.