### PR TITLE
Add latency metric to prometheus-to-sd.

### DIFF
--- a/prometheus-to-sd/main.go
+++ b/prometheus-to-sd/main.go
@@ -172,11 +172,11 @@ func readAndPushDataToStackdriver(stackdriverService *v3.Service, gceConf *confi
 		// road will jump to next iteration of the loop.
 		select {
 		case <-exportTicker:
-			ts, err := timeSeriesBuilder.Build()
+			ts, scrapeTimestamp, err := timeSeriesBuilder.Build()
 			if err != nil {
 				glog.Errorf("Could not build time series for component %v: %v", sourceConfig.Component, err)
 			} else {
-				translator.SendToStackdriver(stackdriverService, commonConfig, ts)
+				translator.SendToStackdriver(stackdriverService, commonConfig, ts, scrapeTimestamp)
 			}
 		default:
 		}
@@ -200,11 +200,12 @@ func readAndPushDataToStackdriver(stackdriverService *v3.Service, gceConf *confi
 			glog.V(4).Infof("Skipping %v component as there are no metric to expose.", sourceConfig.Component)
 			continue
 		}
+		scrapeTimestamp := time.Now()
 		metrics, err := translator.GetPrometheusMetrics(sourceConfig)
 		if err != nil {
 			glog.V(2).Infof("Error while getting Prometheus metrics %v for component %v", err, sourceConfig.Component)
 			continue
 		}
-		timeSeriesBuilder.Update(metrics, time.Now())
+		timeSeriesBuilder.Update(metrics, scrapeTimestamp)
 	}
 }

--- a/prometheus-to-sd/translator/metrics.go
+++ b/prometheus-to-sd/translator/metrics.go
@@ -52,6 +52,15 @@ var (
 		},
 		[]string{"component_name", "metric_name"},
 	)
+
+	metricIngestionLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "metric_ingestion_latency_seconds",
+			Help:    "Time passed from the moment, when metric was scraped from the monitored component till it was pushed to the Stackdriver",
+			Buckets: prometheus.ExponentialBuckets(1.0, 1.5, 12),
+		},
+		[]string{"component_name"},
+	)
 )
 
 func init() {
@@ -59,4 +68,5 @@ func init() {
 	prometheus.MustRegister(timeseriesPushed)
 	prometheus.MustRegister(timeseriesDropped)
 	prometheus.MustRegister(metricFamilyDropped)
+	prometheus.MustRegister(metricIngestionLatency)
 }

--- a/prometheus-to-sd/translator/translator.go
+++ b/prometheus-to-sd/translator/translator.go
@@ -70,15 +70,15 @@ func (t *TimeSeriesBuilder) Update(batch *PrometheusResponse, timestamp time.Tim
 }
 
 // Build returns a new TimeSeries array and restarts the internal state.
-func (t *TimeSeriesBuilder) Build() ([]*v3.TimeSeries, error) {
+func (t *TimeSeriesBuilder) Build() ([]*v3.TimeSeries, time.Time, error) {
 	var ts []*v3.TimeSeries
 	if t.batch == nil {
-		return ts, nil
+		return ts, time.Now(), nil
 	}
 	defer func() { t.batch = nil }()
 	metricFamilies, err := t.batch.metrics.Build(t.config, t.cache)
 	if err != nil {
-		return ts, err
+		return ts, time.Now(), err
 	}
 	// Get start time before whitelisting, because process start time
 	// metric is likely not to be whitelisted.
@@ -97,7 +97,7 @@ func (t *TimeSeriesBuilder) Build() ([]*v3.TimeSeries, error) {
 			ts = append(ts, f...)
 		}
 	}
-	return ts, nil
+	return ts, t.batch.timestamp, nil
 }
 
 // OmitComponentName removes from the metric names prefix that is equal to component name.


### PR DESCRIPTION
It will help to estimate delay between moment when metric was scraped
and when it was send to the Stackdriver.