### PR TITLE
Bump version of prometheus-to-sd to 0.7.2.

### DIFF
--- a/prometheus-to-sd/Makefile
+++ b/prometheus-to-sd/Makefile
@@ -16,7 +16,7 @@ all: build
 
 ENVVAR = GOOS=linux GOARCH=amd64 CGO_ENABLED=0
 PREFIX = staging-k8s.gcr.io
-TAG = v0.7.0
+TAG = v0.7.2
 
 build:
 	$(ENVVAR) go build -a -o monitor


### PR DESCRIPTION
0.7.1 was already released. It wasn't reflected in the file.