### PR TITLE
Fix memory leak when collecting prometheus metrics.

### DIFF
--- a/prometheus-to-sd/translator/prometheus.go
+++ b/prometheus-to-sd/translator/prometheus.go
@@ -66,7 +66,7 @@ func getPrometheusMetrics(config *config.SourceConfig) (*PrometheusResponse, err
 }
 
 // Allow insecure https connections
-var client = &http.Client{
+var prometheusHttpClient = &http.Client{
 	Transport: &http.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
@@ -84,7 +84,7 @@ func doPrometheusRequest(url string, auth config.AuthConfig) (resp *http.Respons
 	} else if len(auth.Token) > 0 {
 		request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", auth.Token))
 	}
-	return client.Do(request)
+	return prometheusHttpClient.Do(request)
 }
 
 // Build performs parsing and processing of the prometheus metrics response.

--- a/prometheus-to-sd/translator/prometheus.go
+++ b/prometheus-to-sd/translator/prometheus.go
@@ -65,15 +65,16 @@ func getPrometheusMetrics(config *config.SourceConfig) (*PrometheusResponse, err
 	return &PrometheusResponse{rawResponse: string(body)}, nil
 }
 
-func doPrometheusRequest(url string, auth config.AuthConfig) (resp *http.Response, err error) {
-	// Allow insecure https connections
-	client := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true,
-			},
+// Allow insecure https connections
+var client = &http.Client{
+	Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
 		},
-	}
+	},
+}
+
+func doPrometheusRequest(url string, auth config.AuthConfig) (resp *http.Response, err error) {
 	request, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
For each prometheus metrics request, a separate `http.Client` object is created. After the request is completed, the connections created during its operation remain for the possibility of their reuse. Which leads to the accumulation of goroutine and memory leak.
Instead of creating `http.Client` for each request, we can reuse once created object, similar to how it was done in `net/http` package.