### PR TITLE
Add default value from GCE metadata server, when resource label flags

### DIFF
--- a/hack/verify-flags/exceptions.txt
+++ b/hack/verify-flags/exceptions.txt
@@ -99,7 +99,15 @@ prometheus-to-sd/translator/translator.go:				"cluster_name":   config.GceConfig
 prometheus-to-sd/translator/translator.go:				"namespace_id":   namespace,
 prometheus-to-sd/translator/translator.go:				"pod_id":         pod,
 prometheus-to-sd/translator/translator.go:				"project_id":     config.GceConfig.Project,
+prometheus-to-sd/translator/translator.go:				resourceLabels["node_name"] = config.GceConfig.Instance
+prometheus-to-sd/translator/translator.go:			if _, found := resourceLabels["node_name"]; !found {
+prometheus-to-sd/translator/translator.go:		// When MonitoredResource is "k8s_node", default "node_name" label to GCE instance name.
+prometheus-to-sd/translator/translator.go:		resourceLabels["cluster_name"] = config.GceConfig.Cluster
+prometheus-to-sd/translator/translator.go:		resourceLabels["project_id"] = config.GceConfig.Project
+prometheus-to-sd/translator/translator.go:	if _, found := resourceLabels["cluster_name"]; !found {
+prometheus-to-sd/translator/translator.go:	if _, found := resourceLabels["project_id"]; !found {
 prometheus-to-sd/translator/translator.go:	resourceLabels["pod_name"] = pod
+prometheus-to-sd/translator/translator_test.go:					"cluster_name":     "test-cluster",
 prometheus-to-sd/translator/translator_test.go:					"cluster_name": "test-cluster",
 prometheus-to-sd/translator/translator_test.go:					"cluster_name": "test-cluster",
 prometheus-to-sd/translator/translator_test.go:					"cluster_name": "test-cluster",
@@ -107,16 +115,21 @@ prometheus-to-sd/translator/translator_test.go:					"node_name":    "test-node",
 prometheus-to-sd/translator/translator_test.go:					"project_id":   "test-project",
 prometheus-to-sd/translator/translator_test.go:					"project_id":   "test-project",
 prometheus-to-sd/translator/translator_test.go:					"project_id":   "test-project",
+prometheus-to-sd/translator/translator_test.go:				"cluster_name":     "test-cluster",
 prometheus-to-sd/translator/translator_test.go:				"cluster_name":   "test-cluster",
 prometheus-to-sd/translator/translator_test.go:				"cluster_name":   "test-cluster",
 prometheus-to-sd/translator/translator_test.go:				"cluster_name":   "test-cluster",
 prometheus-to-sd/translator/translator_test.go:				"cluster_name": "test-cluster",
+prometheus-to-sd/translator/translator_test.go:				"cluster_name": "test-cluster",
 prometheus-to-sd/translator/translator_test.go:				"namespace_id":   "",
+prometheus-to-sd/translator/translator_test.go:				"node_name":    "test-instance",
 prometheus-to-sd/translator/translator_test.go:				"node_name":    "test-node",
 prometheus-to-sd/translator/translator_test.go:				"pod_id":         "",
 prometheus-to-sd/translator/translator_test.go:				"pod_name":       "test-pod",
 prometheus-to-sd/translator/translator_test.go:				"pod_name":       "test-pod",
+prometheus-to-sd/translator/translator_test.go:				"project_id":       "default-project",
 prometheus-to-sd/translator/translator_test.go:				"project_id":     "test-project",
 prometheus-to-sd/translator/translator_test.go:				"project_id":     "test-project",
 prometheus-to-sd/translator/translator_test.go:				"project_id":     "test-project",
+prometheus-to-sd/translator/translator_test.go:				"project_id":   "test-project",
 prometheus-to-sd/translator/translator_test.go:				"project_id":   "test-project",

--- a/prometheus-to-sd/Makefile
+++ b/prometheus-to-sd/Makefile
@@ -16,7 +16,7 @@ all: build
 
 ENVVAR = GOOS=linux GOARCH=amd64 CGO_ENABLED=0
 PREFIX = staging-k8s.gcr.io
-TAG = v0.8.0
+TAG = v0.8.1
 
 build:
 	$(ENVVAR) go build -a -o monitor

--- a/prometheus-to-sd/README.md
+++ b/prometheus-to-sd/README.md
@@ -45,7 +45,7 @@ the component through the additional flags or omitted. `container_name` is
 always empty for now. Field `zone` is overridable via flag.
 
 From 0.8.0, prometheus-to-sd can also take `monitoredResourceLabels` flag to explicitly specify all MonitoredResource labels as a k8s node.
-When this flag is used, prometheus-to-sd will not automatically determine any labels from GCE metadata server, and all of them will have to be explicitly specified.
+When this flag is used, prometheus-to-sd will still fetch labels from GCE metadata server, but all of them will be overwritten if explicitly specified.
 This flag needs to be used together with `monitoredResourceTypePrefix` all the time.
 If `pod-id`, `namespace-id` flags aren't specified, or Prometheus-to-sd isn't configured to extract them from metric labels, metrics will be written as node metrics.
 E.g, if `monitored-resource-type-prefix` = "k8s_", metrics will be written to "k8s_node" type, if `namespace-id` or `pod-id` isn't specified.

--- a/prometheus-to-sd/config/gce_config.go
+++ b/prometheus-to-sd/config/gce_config.go
@@ -30,7 +30,9 @@ type GceConfig struct {
 	Zone            string
 	Cluster         string
 	ClusterLocation string
-	Instance        string
+	// This is actually instance name.
+	Instance   string
+	InstanceId string
 }
 
 // GetGceConfig builds GceConfig based on the provided prefix and metadata server available on GCE.
@@ -89,6 +91,11 @@ func GetGceConfig(project, cluster, clusterLocation, zone, node string) (*GceCon
 		}
 	}
 
+	instanceId, err := gce.InstanceID()
+	if err != nil {
+		return nil, fmt.Errorf("error while getting instance id: %v", err)
+	}
+
 	if zone == "" {
 		zone, err = gce.Zone()
 		if err != nil {
@@ -102,5 +109,6 @@ func GetGceConfig(project, cluster, clusterLocation, zone, node string) (*GceCon
 		Cluster:         cluster,
 		ClusterLocation: clusterLocation,
 		Instance:        node,
+		InstanceId:      instanceId,
 	}, nil
 }

--- a/prometheus-to-sd/main.go
+++ b/prometheus-to-sd/main.go
@@ -66,8 +66,13 @@ var (
 	projectOverride = flag.String("project-id", "",
 		"GCP project to send metrics to. If not set, defaults to value from GCE Metadata Server.")
 	monitoredResourceTypePrefix = flag.String("monitored-resource-type-prefix", "", "MonitoredResource type prefix, to be appended by 'container', 'pod', and 'node'.")
-	monitoredResourceLabels     = flag.String("monitored-resource-labels", "", "Manually specified MonitoredResource labels. It is in URL parameter format, like 'A=B&C=D&E=F'. When this field is specified, 'monitored-resource-type-prefix' is also required. To note: 'namespace-name', 'pod-name', and 'container-name' should not be provided in this flag and they will always be overwritten by values in other command line flags.")
-	omitComponentName           = flag.Bool("omit-component-name", true,
+	monitoredResourceLabels     = flag.String("monitored-resource-labels", "", "Manually specified MonitoredResource labels. "+
+		"It is in URL parameter format, like 'A=B&C=D&E=F'. "+
+		"When this field is specified, 'monitored-resource-type-prefix' is also required. "+
+		"By default, Prometheus-to-sd will read from GCE metadata server to fetch project id, cluster name, cluster location, and instance id. So these fields are optional in this flag. "+
+		"If these values are specified in this flag, they will overwrite the value from GCE metadata server. "+
+		"To note: 'namespace-name', 'pod-name', and 'container-name' should not be provided in this flag and they will always be overwritten by values in other command line flags.")
+	omitComponentName = flag.Bool("omit-component-name", true,
 		"If metric name starts with the component name then this substring is removed to keep metric name shorter.")
 	debugPort      = flag.Uint("port", 6061, "Port on which debug information is exposed.")
 	dynamicSources = flags.Uris{}


### PR DESCRIPTION
Default project_id, cluster_name, location, and instance_id (or node_name) labels to values from GCE metadata server.