### PR TITLE
Change default schemaPrefix flag in kubelet-to-gcm

### DIFF
--- a/kubelet-to-gcm/monitor/main/daemon.go
+++ b/kubelet-to-gcm/monitor/main/daemon.go
@@ -44,7 +44,7 @@ const (
 )
 
 var (
-	schemaPrefix            = flag.String("schema-prefix", "k8s_", "MonitoredResource type prefix, to be appended by 'container', 'pod', and 'node'.")
+	schemaPrefix            = flag.String("schema-prefix", "", "MonitoredResource type prefix, to be appended by 'container', 'pod', and 'node'.")
 	monitoredResourceLabels = flag.String("monitored-resource-labels", "", "Manually specified MonitoredResource labels.")
 	// Flags to identify the Kubelet.
 	zone            = flag.String("zone", "use-gce", "The zone where this kubelet lives.")

--- a/kubelet-to-gcm/monitor/main/daemon.go
+++ b/kubelet-to-gcm/monitor/main/daemon.go
@@ -44,7 +44,8 @@ const (
 )
 
 var (
-	schemaPrefix            = flag.String("schema-prefix", "", "MonitoredResource type prefix, to be appended by 'container', 'pod', and 'node'.")
+	schemaPrefix = flag.String("schema-prefix", "", "MonitoredResource type prefix, to be appended by 'container', 'pod', and 'node'."+
+		"When empty, old resource model (gke_container) is used. k8s_ prefix uses new model, with separate pod/container/node.")
 	monitoredResourceLabels = flag.String("monitored-resource-labels", "", "Manually specified MonitoredResource labels.")
 	// Flags to identify the Kubelet.
 	zone            = flag.String("zone", "use-gce", "The zone where this kubelet lives.")


### PR DESCRIPTION
schemaPrefix values:
"" - old resource model used, "gke_container"
"k8s_" - new resource model, with separate pod/container/node