### PR TITLE
Close event-exporter's stop channel after system terminating signal.

### DIFF
--- a/event-exporter/main.go
+++ b/event-exporter/main.go
@@ -50,7 +50,8 @@ func newSystemStopChannel() chan struct{} {
 		sig := <-c
 		glog.Infof("Received signal %s, terminating", sig.String())
 
-		ch <- struct{}{}
+		// Close stop channel to make sure every goroutine will receive stop signal.
+		close(ch)
 	}()
 
 	return ch


### PR DESCRIPTION
Just close the stop channel to make sure every goroutine will receive stop signal. Otherwise event-exporter won't exit if received system terminating signal
#329 