### PR TITLE
prometheus-to-sd : stop exposing /debug/expvars endpoint on all interfaces by default

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -23,6 +23,7 @@ configuration-name
 current-release-pr
 custom-error-service
 datasource
+debug-address
 default-backend-service
 default-return-code
 default-ssl-certificate

--- a/prometheus-to-sd/Makefile
+++ b/prometheus-to-sd/Makefile
@@ -16,7 +16,7 @@ all: build
 
 ENVVAR = GOOS=linux GOARCH=amd64 CGO_ENABLED=0
 PREFIX = staging-k8s.gcr.io
-TAG = v0.9.4
+TAG = v0.10.0
 
 build:
 	$(ENVVAR) go build -mod=vendor -a -o monitor

--- a/prometheus-to-sd/main.go
+++ b/prometheus-to-sd/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"expvar"
 	"flag"
 	"fmt"
 	"net/http"
@@ -73,7 +74,10 @@ var (
 		"To note: 'namespace-name', 'pod-name', and 'container-name' should not be provided in this flag and they will always be overwritten by values in other command line flags.")
 	omitComponentName = flag.Bool("omit-component-name", true,
 		"If metric name starts with the component name then this substring is removed to keep metric name shorter.")
-	debugPort      = flag.Uint("port", 6061, "Port on which debug information is exposed.")
+	metricsPort    = flag.Uint("port", 6061, "Port on which metrics are exposed.")
+	listenAddress  = flag.String("listen-address", "", "Interface on which  metrics are exposed.")
+	debugPort      = flag.Uint("debug-port", 16061, "Port on which debug information is exposed.")
+	debugAddress   = flag.String("debug-address", "localhost", "Interface on which debug information is exposed.")
 	dynamicSources = flags.Uris{}
 	scrapeInterval = flag.Duration("scrape-interval", 60*time.Second,
 		"The interval between metric scrapes. If there are multiple scrapes between two exports, the last present value is exported, even when missing from last scraping.")
@@ -133,7 +137,11 @@ func main() {
 
 	go func() {
 		http.Handle("/metrics", promhttp.Handler())
-		glog.Error(http.ListenAndServe(fmt.Sprintf(":%d", *debugPort), nil))
+		glog.Error(http.ListenAndServe(fmt.Sprintf("%s:%d", *listenAddress, *metricsPort), nil))
+	}()
+
+	go func() {
+		glog.Error(http.ListenAndServe(fmt.Sprintf("%s:%d", *debugAddress, *debugPort), expvar.Handler()))
 	}()
 
 	var client *http.Client


### PR DESCRIPTION
 prometheus-to-sd : stop exposing metrics on all interfaces by default, listen just on localhost
