### PR TITLE
Note out of the box integration with GKE

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > It contains source code for tools that are pre-installed in 
 > the GKE clusters.
 
-Google Cloud Operations suite (fka Stackdriver) provides advanced 
+[Google Cloud Operations suite][cloudOperationsSite] (fka Stackdriver) provides advanced 
 monitoring and logging solution that will allow you to get more
 insights into your Kubernetes clusters. If you are a Google
 Kubernetes Engine (GKE) user, you get [integration][k8sMonitoring]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
-# Stackdriver Integration for Kubernetes
+## Google Cloud Operations integration for GKE
 
-This repo contains tools for integrating [Stackdriver][stackdriverSite] with
-your Kubernetes deployment. Stackdriver provides advanced monitoring and logging
-solution that will allow you to get more insight into your Kubernetes clusters.
+> :exclamation: **Tools in this repository are not meant for 
+> end-users.**
+> It contains source code for tools that are pre-installed in 
+> the GKE clusters.
 
-[stackdriverSite]: https://cloud.google.com/stackdriver/
+Google Cloud Operations suite (fka Stackdriver) provides advanced 
+monitoring and logging solution that will allow you to get more
+insights into your Kubernetes clusters. If you are a Google
+Kubernetes Engine (GKE) user, you get [integration][k8sMonitoring]
+with Cloud Monitoring and Logging out of the box.
+
+[k8sMonitoring]: https://cloud.google.com/kubernetes-engine-monitoring
+[cloudOperationsSite]: https://cloud.google.com/products/operations 


### PR DESCRIPTION
Update README to note that tools in this repository are integrated
out of the box with GKE. These tools are not meant for end users.

Change Stackdriver to Cloud Operations.