### PR TITLE
Use default token source when no token URL or project override is provided

### DIFF
--- a/prometheus-to-sd/main.go
+++ b/prometheus-to-sd/main.go
@@ -155,7 +155,11 @@ func main() {
 		}
 		glog.Infof("Created a client with the default credentials")
 	} else {
-		client = oauth2.NewClient(context.Background(), google.ComputeTokenSource(""))
+		ts, err := google.DefaultTokenSource(context.Background(), "")
+		if err != nil {
+			glog.Fatalf("Error creating default token source: %v", err)
+		}
+		client = oauth2.NewClient(context.Background(), ts)
 	}
 
 	stackdriverService, err := v3.New(client)


### PR DESCRIPTION
cc @amujumdar @x13n @44past4 

This PR proposes using `DefaultTokenSource` instead of `ComputeTokenSource` as the token source to fall back on when no explicit token URL or project override is specified. The implication of using [DefaultTokenSource](https://github.com/golang/oauth2/blob/cdc340f7c179dbbfa4afd43b7614e8fcadde4269/google/default.go#L43) is that it'll attempt to load credentials from the location specified via `GOOGLE_APPLICATION_CREDENTIALS` and a few others before falling back to `ComputeTokenSource` (if the application is running on GCE).

Fixes #66 .