### PR TITLE
Bump prom-to-sd version to use DefaultTokenSource by default

### DIFF
--- a/prometheus-to-sd/Makefile
+++ b/prometheus-to-sd/Makefile
@@ -16,7 +16,7 @@ all: build
 
 ENVVAR = GOOS=linux GOARCH=amd64 CGO_ENABLED=0
 PREFIX = staging-k8s.gcr.io
-TAG = v0.10.0
+TAG = v0.11.0
 
 build:
 	$(ENVVAR) go build -mod=vendor -a -o monitor


### PR DESCRIPTION
cc @x13n 

Bump `prom-to-sd` version to pick up the changes in #349 to use `DefaultTokenSource` when no token URL or project override is provided.

If the change is deemed backward incompatible enough to justify a major version bump, happy to do so.