### PR TITLE
Update custom-metrics-stackdriver-adapter base image

### DIFF
--- a/custom-metrics-stackdriver-adapter/Dockerfile
+++ b/custom-metrics-stackdriver-adapter/Dockerfile
@@ -21,7 +21,7 @@ RUN apk update \
     && apk add --no-cache govendor \
     && govendor license +vendor > /NOTICES
 
-FROM gcr.io/google-containers/debian-base-amd64:1.0.0
+FROM gcr.io/google-containers/debian-base-amd64:v2.0.0
 
 COPY --from=builder /adapter adapter
 

--- a/custom-metrics-stackdriver-adapter/Makefile
+++ b/custom-metrics-stackdriver-adapter/Makefile
@@ -3,7 +3,7 @@ GOOS?=linux
 OUT_DIR?=build
 PACKAGE=github.com/GoogleCloudPlatform/k8s-stackdriver/custom-metrics-stackdriver-adapter
 PREFIX?=staging-k8s.gcr.io
-TAG = v0.11.0
+TAG = v0.11.3
 PKG := $(shell find pkg/* -type f)
 
 .PHONY: build docker push test clean


### PR DESCRIPTION
Update the base image used for the custom-metrics-stackdriver-adapter to
fix CVE-2017-14062