### PR TITLE
Rebase custom-metrics-sd-adapter on `distroless`

### DIFF
--- a/custom-metrics-stackdriver-adapter/Dockerfile
+++ b/custom-metrics-stackdriver-adapter/Dockerfile
@@ -16,13 +16,12 @@ FROM golang:1.13-alpine as builder
 WORKDIR ${GOPATH}/src/github.com/GoogleCloudPlatform/k8s-stackdriver/custom-metrics-stackdriver-adapter
 COPY . ./
 RUN CGO_ENABLED=0 GOOS=linux go build -mod=vendor -o /adapter
+RUN ! ldd cluster-addons-bootstrap # Assert that the compiled bin is statically linked
 
 RUN apk update \
     && apk add --no-cache govendor \
     && govendor license +vendor > /NOTICES
 
-FROM gcr.io/google-containers/debian-base-amd64:v2.0.0
+FROM gcr.io/distroless/static
 
 COPY --from=builder /adapter adapter
-
-RUN clean-install ca-certificates


### PR DESCRIPTION
Rebasing the k8s images to distroless/static can make the images thinner, safer and less vulnerable.

Meanwhile, it will drastically reduce churn on the total number of k8s images versions. Due to the fact that many images are based on debian base and a vulnerability in debian base (a couple times a month) will result in rebuilding every image, changing the image from debian base to distroless/static can reduce the total number of k8s image versions.

See: https://github.com/kubernetes/enhancements/tree/master/keps/sig-release/1729-rebase-images-to-distroless
https://github.com/kubernetes/enhancements/issues/1729