### PR TITLE
Use 10000 page size on listing events.

### DIFF
--- a/event-exporter/Makefile
+++ b/event-exporter/Makefile
@@ -19,7 +19,7 @@ BINARY_NAME = event-exporter
 
 PREFIX = staging-k8s.gcr.io
 IMAGE_NAME = event-exporter
-TAG = v0.3.3
+TAG = v0.3.4
 
 build:
 	${ENVVAR} go build -mod=vendor -a -o ${BINARY_NAME}

--- a/event-exporter/watchers/events/watcher.go
+++ b/event-exporter/watchers/events/watcher.go
@@ -36,6 +36,14 @@ const (
 	// the hour, since it takes some time to deliver this event via watch.
 	// 2 hours ought to be enough for anybody.
 	eventStorageTTL = 2 * time.Hour
+
+	// Large clusters can have up to 1M events. Fetching them using default
+	// 500 page requires 2000 requests and is not able to finish before
+	// continuation token will expire.
+	// Value 10000 translates to ~100 requests that each takes 0.5s-1s,
+	// so in total listing should take ~1m, which is still below 2.5m-5m
+	// token expiration time.
+	eventWatchListPageSize = 10000
 )
 
 // OnListFunc represent an action on the initial list of object received
@@ -76,6 +84,7 @@ func NewEventWatcher(client kubernetes.Interface, config *EventWatcherConfig) wa
 			StorageType: watchers.TTLStorage,
 			StorageTTL:  eventStorageTTL,
 		},
-		ResyncPeriod: config.ResyncPeriod,
+		ResyncPeriod:      config.ResyncPeriod,
+		WatchListPageSize: eventWatchListPageSize,
 	})
 }


### PR DESCRIPTION
In large clusters, we see up to 1M events and fetching them using default 500 page size is impossible due to limited token expiration time.

/assign @serathius