### PR TITLE
Add flag-protected support for distributions

### DIFF
--- a/custom-metrics-stackdriver-adapter/adapter.go
+++ b/custom-metrics-stackdriver-adapter/adapter.go
@@ -62,6 +62,9 @@ type stackdriverAdapterServerOptions struct {
 	MetricsAddress string
 	// StackdriverEndpoint to change default Stackdriver endpoint (useful in sandbox).
 	StackdriverEndpoint string
+	// EnableDistributionSupport is a flag that indicates whether or not to allow distributions can
+	// be used (with special reducer labels) in the adapter
+	EnableDistributionSupport bool
 }
 
 func (sa *StackdriverAdapter) makeProviderOrDie(o *stackdriverAdapterServerOptions, rateInterval time.Duration, alignmentPeriod time.Duration) (provider.MetricsProvider, *translator.Translator) {
@@ -106,7 +109,7 @@ func (sa *StackdriverAdapter) makeProviderOrDie(o *stackdriverAdapterServerOptio
 	}
 	conf.GenericConfig.EnableMetrics = true
 
-	translator := translator.NewTranslator(stackdriverService, gceConf, rateInterval, alignmentPeriod, mapper, o.UseNewResourceModel)
+	translator := translator.NewTranslator(stackdriverService, gceConf, rateInterval, alignmentPeriod, mapper, o.UseNewResourceModel, o.EnableDistributionSupport)
 	return adapter.NewStackdriverProvider(client, mapper, gceConf, stackdriverService, translator, rateInterval, o.UseNewResourceModel, o.FallbackForContainerMetrics), translator
 }
 
@@ -148,6 +151,7 @@ func main() {
 		EnableExternalMetricsAPI:    true,
 		FallbackForContainerMetrics: false,
 		EnableCoreMetricsAPI:        false,
+		EnableDistributionSupport:   false,
 	}
 
 	flags.BoolVar(&serverOptions.UseNewResourceModel, "use-new-resource-model", serverOptions.UseNewResourceModel,
@@ -164,6 +168,8 @@ func main() {
 		"Endpoint with port on which Prometheus metrics server should be enabled. Example: localhost:8080. If there is no flag, Prometheus metric server is disabled and monitoring metrics are not collected.")
 	flags.StringVar(&serverOptions.StackdriverEndpoint, "stackdriver-endpoint", "",
 		"Stackdriver Endpoint used by adapter. Default is https://monitoring.googleapis.com/")
+	flags.BoolVar(&serverOptions.EnableDistributionSupport, "enable-distribution-support", serverOptions.EnableDistributionSupport,
+		"enables support for scaling based on distribution values")
 
 	flags.Parse(os.Args)
 

--- a/custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder.go
+++ b/custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder.go
@@ -46,6 +46,7 @@ var (
 		p99: "REDUCE_PERCENTILE_99",
 		p95: "REDUCE_PERCENTILE_95",
 		p50: "REDUCE_PERCENTILE_50",
+		p05: "REDUCE_PERCENTILE_05",
 	}
 )
 
@@ -59,6 +60,7 @@ const (
 	p99 = "PERCENTILE_99"
 	p95 = "PERCENTILE_95"
 	p50 = "PERCENTILE_50"
+	p05 = "PERCENTILE_05"
 )
 
 type clock interface {
@@ -640,7 +642,7 @@ func reducerAndSelectorForDistribution(metricSelector labels.Selector) (string, 
 			}
 			r, ok := percentilesToReducers[percentile]
 			if !ok {
-				return "", nil, NewLabelNotAllowedError("Reducer must use a supported percentile (PERCENTILE_50, PERCENTILE_95, PERCENTILE_99). You used: " + percentile)
+				return "", nil, NewLabelNotAllowedError("Reducer must use a supported percentile (PERCENTILE_05, PERCENTILE_50, PERCENTILE_95, PERCENTILE_99). You used: " + percentile)
 			}
 			reducer = r
 			continue

--- a/custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder.go
+++ b/custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder.go
@@ -41,21 +41,21 @@ var (
 	// allowedCustomMetricsLabelPrefixes and allowedCustomMetricsFullLabelNames specify all metric labels allowed for querying
 	allowedCustomMetricsLabelPrefixes  = []string{"metric.labels"}
 	allowedCustomMetricsFullLabelNames = []string{"reducer"}
-	allowedReducers                    = []string{
-		"REDUCE_NONE",
-		"REDUCE_MEAN",
-		"REDUCE_MIN",
-		"REDUCE_MAX",
-		"REDUCE_SUM",
-		"REDUCE_STDDEV",
-		"REDUCE_COUNT",
-		"REDUCE_COUNT_TRUE",
-		"REDUCE_COUNT_FALSE",
-		"REDUCE_FRACTION_TRUE",
-		"REDUCE_PERCENTILE_99",
-		"REDUCE_PERCENTILE_95",
-		"REDUCE_PERCENTILE_50",
-		"REDUCE_PERCENTILE_05",
+	allowedReducers                    = map[string]bool{
+		"REDUCE_NONE":          true,
+		"REDUCE_MEAN":          true,
+		"REDUCE_MIN":           true,
+		"REDUCE_MAX":           true,
+		"REDUCE_SUM":           true,
+		"REDUCE_STDDEV":        true,
+		"REDUCE_COUNT":         true,
+		"REDUCE_COUNT_TRUE":    true,
+		"REDUCE_COUNT_FALSE":   true,
+		"REDUCE_FRACTION_TRUE": true,
+		"REDUCE_PERCENTILE_99": true,
+		"REDUCE_PERCENTILE_95": true,
+		"REDUCE_PERCENTILE_50": true,
+		"REDUCE_PERCENTILE_05": true,
 	}
 )
 
@@ -309,15 +309,6 @@ func getNodeNames(list *v1.NodeList) []string {
 	return resourceNames
 }
 
-func isAlloedReducer(reducer string) bool {
-	for _, r := range allowedReducers {
-		if reducer == r {
-			return true
-		}
-	}
-	return false
-}
-
 func isAllowedLabelName(labelName string, allowedLabelPrefixes []string, allowedFullLabelNames []string) bool {
 	for _, prefix := range allowedLabelPrefixes {
 		if strings.HasPrefix(labelName, prefix+".") {
@@ -462,7 +453,7 @@ func (t *Translator) filterForSelector(metricSelector labels.Selector, allowedLa
 			if !found {
 				return "", "", NewLabelNotAllowedError("Reducer must specify a value")
 			}
-			if !isAlloedReducer(r) {
+			if !allowedReducers[r] {
 				return "", "", NewLabelNotAllowedError("Specified reducer is not supported: " + r)
 			}
 			reducer = r

--- a/custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder.go
+++ b/custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder.go
@@ -130,18 +130,7 @@ func (t *Translator) GetSDReqForPods(podList *v1.PodList, metricName string, met
 	}
 
 	if t.supportDistributions && isDistribution(metricSelector) {
-		reducer, selector, err := reducerAndSelectorForDistribution(metricSelector)
-		if err != nil {
-			return nil, err
-		}
-		if selector.Empty() {
-			return t.createDistributionPercentileRequestProject(filter, reducer), nil
-		}
-		filterForSelector, err := t.filterForSelector(selector, allowedCustomMetricsLabelPrefixes, allowedCustomMetricsFullLabelNames)
-		if err != nil {
-			return nil, err
-		}
-		return t.createDistributionPercentileRequestProject(joinFilters(filterForSelector, filter), reducer), nil
+		return t.handleDistribution(metricSelector, filter)
 	}
 
 	filterForSelector, err := t.filterForSelector(metricSelector, allowedCustomMetricsLabelPrefixes, allowedCustomMetricsFullLabelNames)
@@ -182,18 +171,7 @@ func (t *Translator) GetSDReqForContainersWithNames(resourceNames []string, metr
 		return t.createListTimeseriesRequest(filter, metricKind), nil
 	}
 	if t.supportDistributions && isDistribution(metricSelector) {
-		reducer, selector, err := reducerAndSelectorForDistribution(metricSelector)
-		if err != nil {
-			return nil, err
-		}
-		if selector.Empty() {
-			return t.createDistributionPercentileRequestProject(filter, reducer), nil
-		}
-		filterForSelector, err := t.filterForSelector(selector, allowedCustomMetricsLabelPrefixes, allowedCustomMetricsFullLabelNames)
-		if err != nil {
-			return nil, err
-		}
-		return t.createDistributionPercentileRequestProject(joinFilters(filterForSelector, filter), reducer), nil
+		return t.handleDistribution(metricSelector, filter)
 	}
 	filterForSelector, err := t.filterForSelector(metricSelector, allowedCustomMetricsLabelPrefixes, allowedCustomMetricsFullLabelNames)
 	if err != nil {
@@ -234,18 +212,7 @@ func (t *Translator) GetSDReqForNodesWithNames(resourceNames []string, metricNam
 		return t.createListTimeseriesRequest(filter, metricKind), nil
 	}
 	if t.supportDistributions && isDistribution(metricSelector) {
-		reducer, selector, err := reducerAndSelectorForDistribution(metricSelector)
-		if err != nil {
-			return nil, err
-		}
-		if selector.Empty() {
-			return t.createDistributionPercentileRequestProject(filter, reducer), nil
-		}
-		filterForSelector, err := t.filterForSelector(selector, allowedCustomMetricsLabelPrefixes, allowedCustomMetricsFullLabelNames)
-		if err != nil {
-			return nil, err
-		}
-		return t.createDistributionPercentileRequestProject(joinFilters(filterForSelector, filter), reducer), nil
+		return t.handleDistribution(metricSelector, filter)
 	}
 	filterForSelector, err := t.filterForSelector(metricSelector, allowedCustomMetricsLabelPrefixes, allowedCustomMetricsFullLabelNames)
 	if err != nil {
@@ -266,18 +233,7 @@ func (t *Translator) GetExternalMetricRequest(metricName string, metricKind stri
 		return t.createListTimeseriesRequest(filterForMetric, metricKind), nil
 	}
 	if t.supportDistributions && isDistribution(metricSelector) {
-		reducer, selector, err := reducerAndSelectorForDistribution(metricSelector)
-		if err != nil {
-			return nil, err
-		}
-		if selector.Empty() {
-			return t.createDistributionPercentileRequestProject(filterForMetric, reducer), nil
-		}
-		filterForSelector, err := t.filterForSelector(selector, allowedCustomMetricsLabelPrefixes, allowedCustomMetricsFullLabelNames)
-		if err != nil {
-			return nil, err
-		}
-		return t.createDistributionPercentileRequestProject(joinFilters(filterForSelector, filterForMetric), reducer), nil
+		return t.handleDistribution(metricSelector, filterForMetric)
 	}
 	filterForSelector, err := t.filterForSelector(metricSelector, allowedExternalMetricsLabelPrefixes, allowedExternalMetricsFullLabelNames)
 	if err != nil {
@@ -650,4 +606,19 @@ func reducerAndSelectorForDistribution(metricSelector labels.Selector) (string, 
 		newSelector = newSelector.Add(*req.DeepCopy())
 	}
 	return reducer, newSelector, nil
+}
+
+func (t *Translator) handleDistribution(metricSelector labels.Selector, filter string) (*stackdriver.ProjectsTimeSeriesListCall, error) {
+	reducer, selector, err := reducerAndSelectorForDistribution(metricSelector)
+	if err != nil {
+		return nil, err
+	}
+	if selector.Empty() {
+		return t.createDistributionPercentileRequestProject(filter, reducer), nil
+	}
+	filterForSelector, err := t.filterForSelector(selector, allowedCustomMetricsLabelPrefixes, allowedCustomMetricsFullLabelNames)
+	if err != nil {
+		return nil, err
+	}
+	return t.createDistributionPercentileRequestProject(joinFilters(filterForSelector, filter), reducer), nil
 }

--- a/custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder.go
+++ b/custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder.go
@@ -41,12 +41,21 @@ var (
 	// allowedCustomMetricsLabelPrefixes and allowedCustomMetricsFullLabelNames specify all metric labels allowed for querying
 	allowedCustomMetricsLabelPrefixes  = []string{"metric.labels"}
 	allowedCustomMetricsFullLabelNames = []string{"reducer"}
-
-	percentilesToReducers = map[string]string{
-		p99: "REDUCE_PERCENTILE_99",
-		p95: "REDUCE_PERCENTILE_95",
-		p50: "REDUCE_PERCENTILE_50",
-		p05: "REDUCE_PERCENTILE_05",
+	allowedReducers                    = []string{
+		"REDUCE_NONE",
+		"REDUCE_MEAN",
+		"REDUCE_MIN",
+		"REDUCE_MAX",
+		"REDUCE_SUM",
+		"REDUCE_STDDEV",
+		"REDUCE_COUNT",
+		"REDUCE_COUNT_TRUE",
+		"REDUCE_COUNT_FALSE",
+		"REDUCE_FRACTION_TRUE",
+		"REDUCE_PERCENTILE_99",
+		"REDUCE_PERCENTILE_95",
+		"REDUCE_PERCENTILE_50",
+		"REDUCE_PERCENTILE_05",
 	}
 )
 
@@ -55,12 +64,6 @@ const (
 	AllNamespaces = ""
 	// MaxNumOfArgsInOneOfFilter is the maximum value of one_of() function allowed in Stackdriver Filters
 	MaxNumOfArgsInOneOfFilter = 100
-
-	// distribution percentiles
-	p99 = "PERCENTILE_99"
-	p95 = "PERCENTILE_95"
-	p50 = "PERCENTILE_50"
-	p05 = "PERCENTILE_05"
 )
 
 type clock interface {
@@ -103,12 +106,15 @@ func NewTranslator(service *stackdriver.Service, gceConf *config.GceConfig, rate
 // podList is required to be no longer than MaxNumOfArgsInOneOfFilter items. This is enforced by limitation of
 // "one_of()" operator in Stackdriver filters, see documentation:
 // https://cloud.google.com/monitoring/api/v3/filters
-func (t *Translator) GetSDReqForPods(podList *v1.PodList, metricName string, metricKind string, metricSelector labels.Selector, namespace string) (*stackdriver.ProjectsTimeSeriesListCall, error) {
+func (t *Translator) GetSDReqForPods(podList *v1.PodList, metricName, metricKind, metricValueType string, metricSelector labels.Selector, namespace string) (*stackdriver.ProjectsTimeSeriesListCall, error) {
 	if len(podList.Items) == 0 {
 		return nil, apierr.NewBadRequest("No objects matched provided selector")
 	}
 	if len(podList.Items) > MaxNumOfArgsInOneOfFilter {
 		return nil, apierr.NewInternalError(fmt.Errorf("GetSDReqForPods called with %v pod list, but allowed limit is %v pods", len(podList.Items), MaxNumOfArgsInOneOfFilter))
+	}
+	if metricValueType == "DISTRIBUTION" && !t.supportDistributions {
+		return nil, apierr.NewBadRequest("Distributions are not supported")
 	}
 	var filter string
 	if t.useNewResourceModel {
@@ -126,38 +132,37 @@ func (t *Translator) GetSDReqForPods(podList *v1.PodList, metricName string, met
 			t.legacyFilterForPods(resourceIDs))
 	}
 	if metricSelector.Empty() {
-		return t.createListTimeseriesRequest(filter, metricKind), nil
+		return t.createListTimeseriesRequest(filter, metricKind, metricValueType, ""), nil
 	}
 
-	if t.supportDistributions && isDistribution(metricSelector) {
-		return t.handleDistribution(metricSelector, filter)
-	}
-
-	filterForSelector, err := t.filterForSelector(metricSelector, allowedCustomMetricsLabelPrefixes, allowedCustomMetricsFullLabelNames)
+	filterForSelector, reducer, err := t.filterForSelector(metricSelector, allowedCustomMetricsLabelPrefixes, allowedCustomMetricsFullLabelNames)
 	if err != nil {
 		return nil, err
 	}
-	return t.createListTimeseriesRequest(joinFilters(filterForSelector, filter), metricKind), nil
+	return t.createListTimeseriesRequest(joinFilters(filterForSelector, filter), metricKind, metricValueType, reducer), nil
 }
 
 // GetSDReqForContainers returns Stackdriver request for container resource from multiple pods.
 // podList is required to be no longer than MaxNumOfArgsInOneOfFilter items. This is enforced by limitation of
 // "one_of()" operator in Stackdriver filters, see documentation:
 // https://cloud.google.com/monitoring/api/v3/filters
-func (t *Translator) GetSDReqForContainers(podList *v1.PodList, metricName string, metricKind string, metricSelector labels.Selector, namespace string) (*stackdriver.ProjectsTimeSeriesListCall, error) {
+func (t *Translator) GetSDReqForContainers(podList *v1.PodList, metricName, metricKind, metricValueType string, metricSelector labels.Selector, namespace string) (*stackdriver.ProjectsTimeSeriesListCall, error) {
 	resourceNames := getPodNames(podList)
-	return t.GetSDReqForContainersWithNames(resourceNames, metricName, metricKind, metricSelector, namespace)
+	return t.GetSDReqForContainersWithNames(resourceNames, metricName, metricKind, metricValueType, metricSelector, namespace)
 }
 
 // GetSDReqForContainersWithNames instead of PodList takes array of Pod names as first argument.
 // Request for PodList is expensive and not always necessary so it's better to use this method.
 // Assumes that resourceNames are double-quoted string.
-func (t *Translator) GetSDReqForContainersWithNames(resourceNames []string, metricName string, metricKind string, metricSelector labels.Selector, namespace string) (*stackdriver.ProjectsTimeSeriesListCall, error) {
+func (t *Translator) GetSDReqForContainersWithNames(resourceNames []string, metricName, metricKind, metricValueType string, metricSelector labels.Selector, namespace string) (*stackdriver.ProjectsTimeSeriesListCall, error) {
 	if len(resourceNames) == 0 {
 		return nil, apierr.NewBadRequest("No objects matched provided selector")
 	}
 	if len(resourceNames) > MaxNumOfArgsInOneOfFilter {
 		return nil, apierr.NewInternalError(fmt.Errorf("GetSDReqForContainers called with %v pod list, but allowed limit is %v pods", len(resourceNames), MaxNumOfArgsInOneOfFilter))
+	}
+	if metricValueType == "DISTRIBUTION" && !t.supportDistributions {
+		return nil, apierr.NewBadRequest("Distributions are not supported")
 	}
 	if !t.useNewResourceModel {
 		return nil, apierr.NewInternalError(fmt.Errorf("Illegal state! Container metrics works only with new resource model"))
@@ -168,36 +173,36 @@ func (t *Translator) GetSDReqForContainersWithNames(resourceNames []string, metr
 		t.filterForPods(resourceNames, namespace),
 		t.filterForAnyContainer())
 	if metricSelector.Empty() {
-		return t.createListTimeseriesRequest(filter, metricKind), nil
+		return t.createListTimeseriesRequest(filter, metricKind, metricValueType, ""), nil
 	}
-	if t.supportDistributions && isDistribution(metricSelector) {
-		return t.handleDistribution(metricSelector, filter)
-	}
-	filterForSelector, err := t.filterForSelector(metricSelector, allowedCustomMetricsLabelPrefixes, allowedCustomMetricsFullLabelNames)
+	filterForSelector, reducer, err := t.filterForSelector(metricSelector, allowedCustomMetricsLabelPrefixes, allowedCustomMetricsFullLabelNames)
 	if err != nil {
 		return nil, err
 	}
-	return t.createListTimeseriesRequest(joinFilters(filterForSelector, filter), metricKind), nil
+	return t.createListTimeseriesRequest(joinFilters(filterForSelector, filter), metricKind, metricValueType, reducer), nil
 }
 
 // GetSDReqForNodes returns Stackdriver request for query for multiple nodes.
 // nodeList is required to be no longer than MaxNumOfArgsInOneOfFilter items. This is enforced by limitation of
 // "one_of()" operator in Stackdriver filters, see documentation:
 // https://cloud.google.com/monitoring/api/v3/filters
-func (t *Translator) GetSDReqForNodes(nodeList *v1.NodeList, metricName string, metricKind string, metricSelector labels.Selector) (*stackdriver.ProjectsTimeSeriesListCall, error) {
+func (t *Translator) GetSDReqForNodes(nodeList *v1.NodeList, metricName, metricKind, metricValueType string, metricSelector labels.Selector) (*stackdriver.ProjectsTimeSeriesListCall, error) {
 	resourceNames := getNodeNames(nodeList)
-	return t.GetSDReqForNodesWithNames(resourceNames, metricName, metricKind, metricSelector)
+	return t.GetSDReqForNodesWithNames(resourceNames, metricName, metricKind, metricValueType, metricSelector)
 }
 
 // GetSDReqForNodesWithNames instead of NodeList takes array of Node names as first argument.
 // Request for NodeList could be expensive and not always necessary so it's better to use this method.
 // Assumes that resourceNames are double-quoted string.
-func (t *Translator) GetSDReqForNodesWithNames(resourceNames []string, metricName string, metricKind string, metricSelector labels.Selector) (*stackdriver.ProjectsTimeSeriesListCall, error) {
+func (t *Translator) GetSDReqForNodesWithNames(resourceNames []string, metricName, metricKind, metricValueType string, metricSelector labels.Selector) (*stackdriver.ProjectsTimeSeriesListCall, error) {
 	if len(resourceNames) == 0 {
 		return nil, apierr.NewBadRequest("No objects matched provided selector")
 	}
 	if len(resourceNames) > MaxNumOfArgsInOneOfFilter {
 		return nil, apierr.NewInternalError(fmt.Errorf("GetSDReqForNodes called with %v node list, but allowed limit is %v nodes", len(resourceNames), MaxNumOfArgsInOneOfFilter))
+	}
+	if metricValueType == "DISTRIBUTION" && !t.supportDistributions {
+		return nil, apierr.NewBadRequest("Distributions are not supported")
 	}
 	var filter string
 	if !t.useNewResourceModel {
@@ -209,37 +214,33 @@ func (t *Translator) GetSDReqForNodesWithNames(resourceNames []string, metricNam
 		t.filterForNodes(resourceNames),
 		t.filterForAnyNode())
 	if metricSelector.Empty() {
-		return t.createListTimeseriesRequest(filter, metricKind), nil
+		return t.createListTimeseriesRequest(filter, metricKind, metricValueType, ""), nil
 	}
-	if t.supportDistributions && isDistribution(metricSelector) {
-		return t.handleDistribution(metricSelector, filter)
-	}
-	filterForSelector, err := t.filterForSelector(metricSelector, allowedCustomMetricsLabelPrefixes, allowedCustomMetricsFullLabelNames)
+	filterForSelector, reducer, err := t.filterForSelector(metricSelector, allowedCustomMetricsLabelPrefixes, allowedCustomMetricsFullLabelNames)
 	if err != nil {
 		return nil, err
 	}
-	return t.createListTimeseriesRequest(joinFilters(filterForSelector, filter), metricKind), nil
+	return t.createListTimeseriesRequest(joinFilters(filterForSelector, filter), metricKind, metricValueType, reducer), nil
 }
 
 // GetExternalMetricRequest returns Stackdriver request for query for external metric.
-func (t *Translator) GetExternalMetricRequest(metricName string, metricKind string, metricSelector labels.Selector) (*stackdriver.ProjectsTimeSeriesListCall, error) {
+func (t *Translator) GetExternalMetricRequest(metricName, metricKind, metricValueType string, metricSelector labels.Selector) (*stackdriver.ProjectsTimeSeriesListCall, error) {
+	if metricValueType == "DISTRIBUTION" && !t.supportDistributions {
+		return nil, apierr.NewBadRequest("Distributions are not supported")
+	}
 	metricProject, err := t.GetExternalMetricProject(metricSelector)
 	if err != nil {
 		return nil, err
 	}
-
 	filterForMetric := t.filterForMetric(metricName)
 	if metricSelector.Empty() {
-		return t.createListTimeseriesRequest(filterForMetric, metricKind), nil
+		return t.createListTimeseriesRequest(filterForMetric, metricKind, metricValueType, ""), nil
 	}
-	if t.supportDistributions && isDistribution(metricSelector) {
-		return t.handleDistribution(metricSelector, filterForMetric)
-	}
-	filterForSelector, err := t.filterForSelector(metricSelector, allowedExternalMetricsLabelPrefixes, allowedExternalMetricsFullLabelNames)
+	filterForSelector, reducer, err := t.filterForSelector(metricSelector, allowedExternalMetricsLabelPrefixes, allowedExternalMetricsFullLabelNames)
 	if err != nil {
 		return nil, err
 	}
-	return t.createListTimeseriesRequestProject(joinFilters(filterForMetric, filterForSelector), metricKind, metricProject), nil
+	return t.createListTimeseriesRequestProject(joinFilters(filterForMetric, filterForSelector), metricKind, metricProject, metricValueType, reducer), nil
 }
 
 // ListMetricDescriptors returns Stackdriver request for all custom metrics descriptors.
@@ -256,11 +257,11 @@ func (t *Translator) ListMetricDescriptors(fallbackForContainerMetrics bool) *st
 }
 
 // GetMetricKind returns metricKind for metric metricName, obtained from Stackdriver Monitoring API.
-func (t *Translator) GetMetricKind(metricName string, metricSelector labels.Selector) (string, error) {
+func (t *Translator) GetMetricKind(metricName string, metricSelector labels.Selector) (string, string, error) {
 	metricProj := t.config.Project
 	requirements, selectable := metricSelector.Requirements()
 	if !selectable {
-		return "", apierr.NewBadRequest(fmt.Sprintf("Label selector is impossible to match: %s", metricSelector))
+		return "", "", apierr.NewBadRequest(fmt.Sprintf("Label selector is impossible to match: %s", metricSelector))
 	}
 	for _, req := range requirements {
 		if req.Key() == "resource.labels.project_id" {
@@ -268,14 +269,14 @@ func (t *Translator) GetMetricKind(metricName string, metricSelector labels.Sele
 				metricProj = req.Values().List()[0]
 				break
 			}
-			return "", NewLabelNotAllowedError(fmt.Sprintf("Project selector must use '=' or '==': You used %s", req.Operator()))
+			return "", "", NewLabelNotAllowedError(fmt.Sprintf("Project selector must use '=' or '==': You used %s", req.Operator()))
 		}
 	}
 	response, err := t.service.Projects.MetricDescriptors.Get(fmt.Sprintf("projects/%s/metricDescriptors/%s", metricProj, metricName)).Do()
 	if err != nil {
-		return "", NewNoSuchMetricError(metricName, err)
+		return "", "", NewNoSuchMetricError(metricName, err)
 	}
-	return response.MetricKind, nil
+	return response.MetricKind, response.ValueType, nil
 }
 
 // GetExternalMetricProject If the metric has "resource.labels.project_id" as a selector, then use a different project
@@ -306,6 +307,15 @@ func getNodeNames(list *v1.NodeList) []string {
 		resourceNames = append(resourceNames, fmt.Sprintf("%q", item.GetName()))
 	}
 	return resourceNames
+}
+
+func isAlloedReducer(reducer string) bool {
+	for _, r := range allowedReducers {
+		if reducer == r {
+			return true
+		}
+	}
+	return false
 }
 
 func isAllowedLabelName(labelName string, allowedLabelPrefixes []string, allowedFullLabelNames []string) bool {
@@ -348,7 +358,13 @@ func quoteAll(list []string) []string {
 }
 
 func joinFilters(filters ...string) string {
-	return strings.Join(filters, " AND ")
+	nonEmpty := []string{}
+	for _, f := range filters {
+		if f != "" {
+			nonEmpty = append(nonEmpty, f)
+		}
+	}
+	return strings.Join(nonEmpty, " AND ")
 }
 
 func (t *Translator) filterForCluster() string {
@@ -427,26 +443,44 @@ func (t *Translator) legacyFilterForPods(podIDs []string) string {
 	return fmt.Sprintf("resource.labels.pod_id = one_of(%s)", strings.Join(podIDs, ","))
 }
 
-func (t *Translator) filterForSelector(metricSelector labels.Selector, allowedLabelPrefixes []string, allowedFullLabelNames []string) (string, error) {
+func (t *Translator) filterForSelector(metricSelector labels.Selector, allowedLabelPrefixes []string, allowedFullLabelNames []string) (string, string, error) {
 	requirements, selectable := metricSelector.Requirements()
 	if !selectable {
-		return "", apierr.NewBadRequest(fmt.Sprintf("Label selector is impossible to match: %s", metricSelector))
+		return "", "", apierr.NewBadRequest(fmt.Sprintf("Label selector is impossible to match: %s", metricSelector))
 	}
 	filters := []string{}
+	var reducer string
 	for _, req := range requirements {
+		if req.Key() == "reducer" {
+			if req.Operator() != selection.Equals && req.Operator() != selection.DoubleEquals {
+				return "", "", NewLabelNotAllowedError(fmt.Sprintf("Reducer must use '=' or '==': You used %s", req.Operator()))
+			}
+			if req.Values().Len() != 1 {
+				return "", "", NewLabelNotAllowedError("Reducer must select a single value")
+			}
+			r, found := req.Values().PopAny()
+			if !found {
+				return "", "", NewLabelNotAllowedError("Reducer must specify a value")
+			}
+			if !isAlloedReducer(r) {
+				return "", "", NewLabelNotAllowedError("Specified reducer is not supported: " + r)
+			}
+			reducer = r
+			continue
+		}
 		l := req.Values().List()
 		switch req.Operator() {
 		case selection.Equals, selection.DoubleEquals:
 			if isAllowedLabelName(req.Key(), allowedLabelPrefixes, allowedFullLabelNames) {
 				filters = append(filters, fmt.Sprintf("%s = %q", req.Key(), l[0]))
 			} else {
-				return "", NewLabelNotAllowedError(req.Key())
+				return "", "", NewLabelNotAllowedError(req.Key())
 			}
 		case selection.NotEquals:
 			if isAllowedLabelName(req.Key(), allowedLabelPrefixes, allowedFullLabelNames) {
 				filters = append(filters, fmt.Sprintf("%s != %q", req.Key(), l[0]))
 			} else {
-				return "", NewLabelNotAllowedError(req.Key())
+				return "", "", NewLabelNotAllowedError(req.Key())
 			}
 		case selection.In:
 			if isAllowedLabelName(req.Key(), allowedLabelPrefixes, allowedFullLabelNames) {
@@ -456,7 +490,7 @@ func (t *Translator) filterForSelector(metricSelector labels.Selector, allowedLa
 					filters = append(filters, fmt.Sprintf("%s = one_of(%s)", req.Key(), strings.Join(quoteAll(l), ",")))
 				}
 			} else {
-				return "", NewLabelNotAllowedError(req.Key())
+				return "", "", NewLabelNotAllowedError(req.Key())
 			}
 		case selection.NotIn:
 			if isAllowedLabelName(req.Key(), allowedLabelPrefixes, allowedFullLabelNames) {
@@ -466,43 +500,43 @@ func (t *Translator) filterForSelector(metricSelector labels.Selector, allowedLa
 					filters = append(filters, fmt.Sprintf("NOT %s = one_of(%s)", req.Key(), strings.Join(quoteAll(l), ",")))
 				}
 			} else {
-				return "", NewLabelNotAllowedError(req.Key())
+				return "", "", NewLabelNotAllowedError(req.Key())
 			}
 		case selection.Exists:
 			prefix, suffix, err := splitMetricLabel(req.Key(), allowedLabelPrefixes)
 			if err == nil {
 				filters = append(filters, fmt.Sprintf("%s : %s", prefix, suffix))
 			} else {
-				return "", NewLabelNotAllowedError(req.Key())
+				return "", "", NewLabelNotAllowedError(req.Key())
 			}
 		case selection.DoesNotExist:
 			// DoesNotExist is not allowed due to Stackdriver filtering syntax limitation
-			return "", apierr.NewBadRequest("Label selector with operator DoesNotExist is not allowed")
+			return "", "", apierr.NewBadRequest("Label selector with operator DoesNotExist is not allowed")
 		case selection.GreaterThan:
 			if isAllowedLabelName(req.Key(), allowedLabelPrefixes, allowedFullLabelNames) {
 				value, err := strconv.ParseInt(l[0], 10, 64)
 				if err != nil {
-					return "", apierr.NewInternalError(fmt.Errorf("Unexpected error: value %s could not be parsed to integer", l[0]))
+					return "", "", apierr.NewInternalError(fmt.Errorf("Unexpected error: value %s could not be parsed to integer", l[0]))
 				}
 				filters = append(filters, fmt.Sprintf("%s > %v", req.Key(), value))
 			} else {
-				return "", NewLabelNotAllowedError(req.Key())
+				return "", "", NewLabelNotAllowedError(req.Key())
 			}
 		case selection.LessThan:
 			if isAllowedLabelName(req.Key(), allowedLabelPrefixes, allowedFullLabelNames) {
 				value, err := strconv.ParseInt(l[0], 10, 64)
 				if err != nil {
-					return "", apierr.NewInternalError(fmt.Errorf("Unexpected error: value %s could not be parsed to integer", l[0]))
+					return "", "", apierr.NewInternalError(fmt.Errorf("Unexpected error: value %s could not be parsed to integer", l[0]))
 				}
 				filters = append(filters, fmt.Sprintf("%s < %v", req.Key(), value))
 			} else {
-				return "", NewLabelNotAllowedError(req.Key())
+				return "", "", NewLabelNotAllowedError(req.Key())
 			}
 		default:
-			return "", NewOperationNotSupportedError(fmt.Sprintf("Selector with operator %q", req.Operator()))
+			return "", "", NewOperationNotSupportedError(fmt.Sprintf("Selector with operator %q", req.Operator()))
 		}
 	}
-	return strings.Join(filters, " AND "), nil
+	return strings.Join(filters, " AND "), reducer, nil
 }
 
 func (t *Translator) getMetricLabels(series *stackdriver.TimeSeries) map[string]string {
@@ -517,11 +551,11 @@ func (t *Translator) getMetricLabels(series *stackdriver.TimeSeries) map[string]
 	return metricLabels
 }
 
-func (t *Translator) createListTimeseriesRequest(filter string, metricKind string) *stackdriver.ProjectsTimeSeriesListCall {
-	return t.createListTimeseriesRequestProject(filter, metricKind, t.config.Project)
+func (t *Translator) createListTimeseriesRequest(filter, metricKind, metricValueType, reducer string) *stackdriver.ProjectsTimeSeriesListCall {
+	return t.createListTimeseriesRequestProject(filter, metricKind, t.config.Project, metricValueType, reducer)
 }
 
-func (t *Translator) createListTimeseriesRequestProject(filter string, metricKind string, metricProject string) *stackdriver.ProjectsTimeSeriesListCall {
+func (t *Translator) createListTimeseriesRequestProject(filter, metricKind, metricProject, metricValueType, reducer string) *stackdriver.ProjectsTimeSeriesListCall {
 	project := fmt.Sprintf("projects/%s", metricProject)
 	endTime := t.clock.Now()
 	startTime := endTime.Add(-t.reqWindow)
@@ -532,24 +566,18 @@ func (t *Translator) createListTimeseriesRequestProject(filter string, metricKin
 		aligner = "ALIGN_RATE" // Calculates integral of metric on segment and divide it by segment length.
 		alignmentPeriod = t.alignmentPeriod
 	}
-	return t.service.Projects.TimeSeries.List(project).Filter(filter).
+	if metricValueType == "DISTRIBUTION" {
+		aligner = "ALIGN_DELTA"
+	}
+	ptslc := t.service.Projects.TimeSeries.List(project).Filter(filter).
 		IntervalStartTime(startTime.Format(time.RFC3339)).
 		IntervalEndTime(endTime.Format(time.RFC3339)).
 		AggregationPerSeriesAligner(aligner).
 		AggregationAlignmentPeriod(fmt.Sprintf("%vs", int64(alignmentPeriod.Seconds())))
-}
-
-func (t *Translator) createDistributionPercentileRequestProject(filter, reducer string) *stackdriver.ProjectsTimeSeriesListCall {
-	project := fmt.Sprintf("projects/%s", t.config.Project)
-	endTime := t.clock.Now()
-	startTime := endTime.Add(-t.reqWindow)
-
-	return t.service.Projects.TimeSeries.List(project).Filter(filter).
-		IntervalStartTime(startTime.Format(time.RFC3339)).
-		IntervalEndTime(endTime.Format(time.RFC3339)).
-		AggregationPerSeriesAligner("ALIGN_DELTA").
-		AggregationAlignmentPeriod(fmt.Sprintf("%vs", int64(t.alignmentPeriod.Seconds()))).
-		AggregationCrossSeriesReducer(reducer)
+	if reducer != "" {
+		ptslc = ptslc.AggregationCrossSeriesReducer(reducer)
+	}
+	return ptslc
 }
 
 // GetPodItems returns list Pod Objects
@@ -578,47 +606,4 @@ func isDistribution(metricSelector labels.Selector) bool {
 		}
 	}
 	return false
-}
-
-func reducerAndSelectorForDistribution(metricSelector labels.Selector) (string, labels.Selector, error) {
-	reducer := percentilesToReducers[p50]
-	requirements, _ := metricSelector.Requirements()
-	newSelector := labels.NewSelector()
-	for _, req := range requirements {
-		if req.Key() == "reducer" {
-			if req.Operator() != selection.Equals && req.Operator() != selection.DoubleEquals {
-				return "", nil, NewLabelNotAllowedError(fmt.Sprintf("Reducer must use '=' or '==': You used %s", req.Operator()))
-			}
-			if req.Values().Len() != 1 {
-				return "", nil, NewLabelNotAllowedError("Reducer must select a single value")
-			}
-			percentile, found := req.Values().PopAny()
-			if !found {
-				return "", nil, NewLabelNotAllowedError("Reducer must specify a percentile")
-			}
-			r, ok := percentilesToReducers[percentile]
-			if !ok {
-				return "", nil, NewLabelNotAllowedError("Reducer must use a supported percentile (PERCENTILE_05, PERCENTILE_50, PERCENTILE_95, PERCENTILE_99). You used: " + percentile)
-			}
-			reducer = r
-			continue
-		}
-		newSelector = newSelector.Add(*req.DeepCopy())
-	}
-	return reducer, newSelector, nil
-}
-
-func (t *Translator) handleDistribution(metricSelector labels.Selector, filter string) (*stackdriver.ProjectsTimeSeriesListCall, error) {
-	reducer, selector, err := reducerAndSelectorForDistribution(metricSelector)
-	if err != nil {
-		return nil, err
-	}
-	if selector.Empty() {
-		return t.createDistributionPercentileRequestProject(filter, reducer), nil
-	}
-	filterForSelector, err := t.filterForSelector(selector, allowedCustomMetricsLabelPrefixes, allowedCustomMetricsFullLabelNames)
-	if err != nil {
-		return nil, err
-	}
-	return t.createDistributionPercentileRequestProject(joinFilters(filterForSelector, filter), reducer), nil
 }

--- a/custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go
+++ b/custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go
@@ -39,7 +39,7 @@ func TestTranslator_GetSDReqForPods_Single(t *testing.T) {
 		},
 	}
 	metricName := "my/custom/metric"
-	request, err := translator.GetSDReqForPods(&v1.PodList{Items: []v1.Pod{pod}}, metricName, "GAUGE", labels.Everything(), "default")
+	request, err := translator.GetSDReqForPods(&v1.PodList{Items: []v1.Pod{pod}}, metricName, "GAUGE", "INT64", labels.Everything(), "default")
 	if err != nil {
 		t.Errorf("Translation error: %s", err)
 	}
@@ -72,7 +72,7 @@ func TestTranslator_GetSDReqForPods_SingleWithMetricSelector(t *testing.T) {
 	}
 	metricName := "my/custom/metric"
 	metricSelector, _ := labels.Parse("metric.labels.custom=test")
-	request, err := translator.GetSDReqForPods(&v1.PodList{Items: []v1.Pod{pod}}, metricName, "GAUGE", metricSelector, "default")
+	request, err := translator.GetSDReqForPods(&v1.PodList{Items: []v1.Pod{pod}}, metricName, "GAUGE", "INT64", metricSelector, "default")
 	if err != nil {
 		t.Errorf("Translation error: %s", err)
 	}
@@ -106,7 +106,7 @@ func TestTranslator_GetSDReqForPods_SingleWithInvalidMetricSelector(t *testing.T
 	}
 	metricName := "my/custom/metric"
 	metricSelector, _ := labels.Parse("resource.labels.type=container")
-	_, err := translator.GetSDReqForPods(&v1.PodList{Items: []v1.Pod{pod}}, metricName, "GAUGE", metricSelector, "default")
+	_, err := translator.GetSDReqForPods(&v1.PodList{Items: []v1.Pod{pod}}, metricName, "GAUGE", "INT64", metricSelector, "default")
 	if err == nil {
 		t.Error("No translation error")
 	}
@@ -130,7 +130,7 @@ func TestTranslator_GetSDReqForPods_Multiple(t *testing.T) {
 		},
 	}
 	metricName := "my/custom/metric"
-	request, err := translator.GetSDReqForPods(&v1.PodList{Items: []v1.Pod{pod1, pod2}}, metricName, "GAUGE", labels.Everything(), "default")
+	request, err := translator.GetSDReqForPods(&v1.PodList{Items: []v1.Pod{pod1, pod2}}, metricName, "GAUGE", "INT64", labels.Everything(), "default")
 	if err != nil {
 		t.Fatalf("Translation error: %s", err)
 	}
@@ -170,7 +170,7 @@ func TestTranslator_GetSDReqForPods_MultipleWithMetricSelctor(t *testing.T) {
 	}
 	metricName := "my/custom/metric"
 	metricSelector, _ := labels.Parse("metric.labels.custom=test")
-	request, err := translator.GetSDReqForPods(&v1.PodList{Items: []v1.Pod{pod1, pod2}}, metricName, "GAUGE", metricSelector, "default")
+	request, err := translator.GetSDReqForPods(&v1.PodList{Items: []v1.Pod{pod1, pod2}}, metricName, "GAUGE", "INT64", metricSelector, "default")
 	if err != nil {
 		t.Fatalf("Translation error: %s", err)
 	}
@@ -203,7 +203,7 @@ func TestTranslator_GetSDReqForContainers_Single(t *testing.T) {
 		},
 	}
 	metricName := "my/custom/metric"
-	request, err := translator.GetSDReqForContainers(&v1.PodList{Items: []v1.Pod{pod}}, metricName, "GAUGE", labels.Everything(), "default")
+	request, err := translator.GetSDReqForContainers(&v1.PodList{Items: []v1.Pod{pod}}, metricName, "GAUGE", "INT64", labels.Everything(), "default")
 	if err != nil {
 		t.Errorf("Translation error: %s", err)
 	}
@@ -235,7 +235,7 @@ func TestTranslator_GetSDReqForContainers_SingleWithEmptyNamespace(t *testing.T)
 		},
 	}
 	metricName := "my/custom/metric"
-	request, err := translator.GetSDReqForContainers(&v1.PodList{Items: []v1.Pod{pod}}, metricName, "GAUGE", labels.Everything(), AllNamespaces)
+	request, err := translator.GetSDReqForContainers(&v1.PodList{Items: []v1.Pod{pod}}, metricName, "GAUGE", "INT64", labels.Everything(), AllNamespaces)
 	if err != nil {
 		t.Errorf("Translation error: %s", err)
 	}
@@ -266,7 +266,7 @@ func TestTranslator_GetSDReqForContainers_OldResourceModel(t *testing.T) {
 		},
 	}
 	metricName := "my/custom/metric"
-	_, err := translator.GetSDReqForContainers(&v1.PodList{Items: []v1.Pod{pod}}, metricName, "GAUGE", labels.Everything(), "default")
+	_, err := translator.GetSDReqForContainers(&v1.PodList{Items: []v1.Pod{pod}}, metricName, "GAUGE", "INT64", labels.Everything(), "default")
 	if err == nil {
 		t.Errorf("OldResourceModel should not work with GetSDReqForContainers")
 	}
@@ -284,7 +284,7 @@ func TestTranslator_GetSDReqForContainers_SingleWithMetricSelector(t *testing.T)
 	}
 	metricName := "my/custom/metric"
 	metricSelector, _ := labels.Parse("metric.labels.custom=test")
-	request, err := translator.GetSDReqForContainers(&v1.PodList{Items: []v1.Pod{pod}}, metricName, "GAUGE", metricSelector, "default")
+	request, err := translator.GetSDReqForContainers(&v1.PodList{Items: []v1.Pod{pod}}, metricName, "GAUGE", "INT64", metricSelector, "default")
 	if err != nil {
 		t.Errorf("Translation error: %s", err)
 	}
@@ -318,7 +318,7 @@ func TestTranslator_GetSDReqForContainers_SingleWithInvalidMetricSelector(t *tes
 	}
 	metricName := "my/custom/metric"
 	metricSelector, _ := labels.Parse("resource.labels.type=container")
-	_, err := translator.GetSDReqForContainers(&v1.PodList{Items: []v1.Pod{pod}}, metricName, "GAUGE", metricSelector, "default")
+	_, err := translator.GetSDReqForContainers(&v1.PodList{Items: []v1.Pod{pod}}, metricName, "GAUGE", "INT64", metricSelector, "default")
 	if err == nil {
 		t.Error("No translation error")
 	}
@@ -342,7 +342,7 @@ func TestTranslator_GetSDReqForContainers_Multiple(t *testing.T) {
 		},
 	}
 	metricName := "my/custom/metric"
-	request, err := translator.GetSDReqForContainers(&v1.PodList{Items: []v1.Pod{pod1, pod2}}, metricName, "GAUGE", labels.Everything(), "default")
+	request, err := translator.GetSDReqForContainers(&v1.PodList{Items: []v1.Pod{pod1, pod2}}, metricName, "GAUGE", "INT64", labels.Everything(), "default")
 	if err != nil {
 		t.Fatalf("Translation error: %s", err)
 	}
@@ -381,7 +381,7 @@ func TestTranslator_GetSDReqForContainers_MultipleEmptyNamespace(t *testing.T) {
 		},
 	}
 	metricName := "my/custom/metric"
-	request, err := translator.GetSDReqForContainers(&v1.PodList{Items: []v1.Pod{pod1, pod2}}, metricName, "GAUGE", labels.Everything(), AllNamespaces)
+	request, err := translator.GetSDReqForContainers(&v1.PodList{Items: []v1.Pod{pod1, pod2}}, metricName, "GAUGE", "INT64", labels.Everything(), AllNamespaces)
 	if err != nil {
 		t.Fatalf("Translation error: %s", err)
 	}
@@ -420,7 +420,7 @@ func TestTranslator_GetSDReqForContainers_MultipleWithMetricSelctor(t *testing.T
 	}
 	metricName := "my/custom/metric"
 	metricSelector, _ := labels.Parse("metric.labels.custom=test")
-	request, err := translator.GetSDReqForContainers(&v1.PodList{Items: []v1.Pod{pod1, pod2}}, metricName, "GAUGE", metricSelector, "default")
+	request, err := translator.GetSDReqForContainers(&v1.PodList{Items: []v1.Pod{pod1, pod2}}, metricName, "GAUGE", "INT64", metricSelector, "default")
 	if err != nil {
 		t.Fatalf("Translation error: %s", err)
 	}
@@ -453,7 +453,7 @@ func TestTranslator_GetSDReqForNodes(t *testing.T) {
 		},
 	}
 	metricName := "my/custom/metric"
-	request, err := translator.GetSDReqForNodes(&v1.NodeList{Items: []v1.Node{node}}, metricName, "GAUGE", labels.Everything())
+	request, err := translator.GetSDReqForNodes(&v1.NodeList{Items: []v1.Node{node}}, metricName, "GAUGE", "INT64", labels.Everything())
 	if err != nil {
 		t.Errorf("Translation error: %s", err)
 	}
@@ -485,7 +485,7 @@ func TestTranslator_GetSDReqForNodes_withMetricSelector(t *testing.T) {
 	}
 	metricName := "my/custom/metric"
 	metricSelector, _ := labels.Parse("metric.labels.custom=test")
-	request, err := translator.GetSDReqForNodes(&v1.NodeList{Items: []v1.Node{node}}, metricName, "GAUGE", metricSelector)
+	request, err := translator.GetSDReqForNodes(&v1.NodeList{Items: []v1.Node{node}}, metricName, "GAUGE", "INT64", metricSelector)
 	if err != nil {
 		t.Errorf("Translation error: %s", err)
 	}
@@ -522,7 +522,7 @@ func TestTranslator_GetSDReqForPods_legacyResourceModel(t *testing.T) {
 		},
 	}
 	metricName := "my/custom/metric"
-	request, err := translator.GetSDReqForPods(&v1.PodList{Items: []v1.Pod{pod1, pod2}}, metricName, "GAUGE", labels.Everything(), "default")
+	request, err := translator.GetSDReqForPods(&v1.PodList{Items: []v1.Pod{pod1, pod2}}, metricName, "GAUGE", "INT64", labels.Everything(), "default")
 	if err != nil {
 		t.Fatalf("Translation error: %s", err)
 	}
@@ -584,7 +584,7 @@ func TestTranslator_ListMetricDescriptors_legacyResourceType(t *testing.T) {
 }
 func TestTranslator_GetExternalMetricRequest_NoSelector(t *testing.T) {
 	translator, sdService := newFakeTranslatorForExternalMetrics(2*time.Minute, time.Minute, "my-project", time.Date(2017, 1, 2, 13, 2, 0, 0, time.UTC))
-	request, err := translator.GetExternalMetricRequest("custom.googleapis.com/my/metric/name", "GAUGE", labels.NewSelector())
+	request, err := translator.GetExternalMetricRequest("custom.googleapis.com/my/metric/name", "GAUGE", "INT64", labels.NewSelector())
 	if err != nil {
 		t.Fatalf("Translation error: %s", err)
 	}
@@ -606,7 +606,7 @@ func TestTranslator_GetExternalMetricRequest_CorrectSelector_Cumulative(t *testi
 	req3, _ := labels.NewRequirement("resource.labels.pod_name", selection.Exists, []string{})
 	req4, _ := labels.NewRequirement("resource.labels.namespace_name", selection.NotIn, []string{"default", "kube-system"})
 	req5, _ := labels.NewRequirement("metric.labels.my_label", selection.GreaterThan, []string{"86"})
-	request, err := translator.GetExternalMetricRequest("custom.googleapis.com/my/metric/name", "CUMULATIVE", labels.NewSelector().Add(*req1, *req2, *req3, *req4, *req5))
+	request, err := translator.GetExternalMetricRequest("custom.googleapis.com/my/metric/name", "CUMULATIVE", "INT64", labels.NewSelector().Add(*req1, *req2, *req3, *req4, *req5))
 	if err != nil {
 		t.Fatalf("Translation error: %s", err)
 	}
@@ -630,7 +630,7 @@ func TestTranslator_GetExternalMetricRequest_DifferentProject(t *testing.T) {
 	translator, sdService := newFakeTranslatorForExternalMetrics(2*time.Minute, time.Minute, "my-project", time.Date(2017, 1, 2, 13, 2, 0, 0, time.UTC))
 	req1, _ := labels.NewRequirement("resource.type", selection.Equals, []string{"k8s_pod"})
 	req2, _ := labels.NewRequirement("resource.labels.project_id", selection.Equals, []string{"other-project"})
-	request, err := translator.GetExternalMetricRequest("custom.googleapis.com/my/metric/name", "CUMULATIVE", labels.NewSelector().Add(*req1, *req2))
+	request, err := translator.GetExternalMetricRequest("custom.googleapis.com/my/metric/name", "CUMULATIVE", "INT64", labels.NewSelector().Add(*req1, *req2))
 	if err != nil {
 		t.Fatalf("Translation error: %s", err)
 	}
@@ -649,7 +649,7 @@ func TestTranslator_GetExternalMetricRequest_DifferentProject(t *testing.T) {
 
 func TestTranslator_GetExternalMetricRequest_InvalidLabel(t *testing.T) {
 	translator, _ := newFakeTranslatorForExternalMetrics(2*time.Minute, time.Minute, "my-project", time.Date(2017, 1, 2, 13, 2, 0, 0, time.UTC))
-	_, err := translator.GetExternalMetricRequest("custom.googleapis.com/my/metric/name", "GAUGE", labels.SelectorFromSet(labels.Set{
+	_, err := translator.GetExternalMetricRequest("custom.googleapis.com/my/metric/name", "GAUGE", "INT64", labels.SelectorFromSet(labels.Set{
 		"arbitrary-label": "foo",
 	}))
 	expectedError := NewLabelNotAllowedError("arbitrary-label")
@@ -664,7 +664,7 @@ func TestTranslator_GetExternalMetricRequest_OneInvalidRequirement(t *testing.T)
 	req2, _ := labels.NewRequirement("resource.labels.pod_name", selection.Exists, []string{})
 	req3, _ := labels.NewRequirement("resource.labels.namespace_name", selection.NotIn, []string{"default", "kube-system"})
 	req4, _ := labels.NewRequirement("metric.labels.my_label", selection.DoesNotExist, []string{})
-	_, err := translator.GetExternalMetricRequest("custom.googleapis.com/my/metric/name", "GAUGE", labels.NewSelector().Add(*req1, *req2, *req3, *req4))
+	_, err := translator.GetExternalMetricRequest("custom.googleapis.com/my/metric/name", "GAUGE", "INT64", labels.NewSelector().Add(*req1, *req2, *req3, *req4))
 	expectedError := errors.NewBadRequest("Label selector with operator DoesNotExist is not allowed")
 	if *err.(*errors.StatusError) != *expectedError {
 		t.Errorf("Expected status error: %s, but received: %s", expectedError, err)
@@ -682,8 +682,8 @@ func TestTranslator_GetSDReqForPods_Single_Distribution(t *testing.T) {
 		},
 	}
 	metricName := "my/custom/metric"
-	selector, _ := labels.Parse("reducer=PERCENTILE_50")
-	request, err := translator.GetSDReqForPods(&v1.PodList{Items: []v1.Pod{pod}}, metricName, "DELTA", selector, "default")
+	selector, _ := labels.Parse("reducer=REDUCE_PERCENTILE_50")
+	request, err := translator.GetSDReqForPods(&v1.PodList{Items: []v1.Pod{pod}}, metricName, "DELTA", "DISTRIBUTION", selector, "default")
 	if err != nil {
 		t.Errorf("Translation error: %s", err)
 	}
@@ -706,7 +706,7 @@ func TestTranslator_GetSDReqForPods_Single_Distribution(t *testing.T) {
 }
 
 func TestTranslator_GetSDReqForPods_NoSupportDistributions(t *testing.T) {
-	translator, sdService :=
+	translator, _ :=
 		NewFakeTranslator(2*time.Minute, time.Minute, "my-project", "my-cluster", "my-zone", time.Date(2017, 1, 2, 13, 2, 0, 0, time.UTC), true)
 	pod := v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -716,27 +716,11 @@ func TestTranslator_GetSDReqForPods_NoSupportDistributions(t *testing.T) {
 		},
 	}
 	metricName := "my/custom/metric"
-	req, _ := labels.NewRequirement("reducer", selection.Equals, []string{"PERCENTILE_50"})
+	req, _ := labels.NewRequirement("reducer", selection.Equals, []string{"REDUCE_PERCENTILE_50"})
 	selector := labels.NewSelector().Add(*req)
-	request, err := translator.GetSDReqForPods(&v1.PodList{Items: []v1.Pod{pod}}, metricName, "DELTA", selector, "default")
-	if err != nil {
-		t.Errorf("Translation error: %s", err)
-	}
-	expectedRequest := sdService.Projects.TimeSeries.List("projects/my-project").
-		Filter("reducer = \"PERCENTILE_50\" " +
-			"AND metric.type = \"my/custom/metric\" " +
-			"AND resource.labels.project_id = \"my-project\" " +
-			"AND resource.labels.cluster_name = \"my-cluster\" " +
-			"AND resource.labels.location = \"my-zone\" " +
-			"AND resource.labels.namespace_name = \"default\" " +
-			"AND resource.labels.pod_name = \"my-pod-name\" " +
-			"AND resource.type = \"k8s_pod\"").
-		IntervalStartTime("2017-01-02T13:00:00Z").
-		IntervalEndTime("2017-01-02T13:02:00Z").
-		AggregationPerSeriesAligner("ALIGN_RATE").
-		AggregationAlignmentPeriod("60s")
-	if !reflect.DeepEqual(*request, *expectedRequest) {
-		t.Errorf("Unexpected result. Expected: \n%v,\n received: \n%v", expectedRequest, request)
+	_, err := translator.GetSDReqForPods(&v1.PodList{Items: []v1.Pod{pod}}, metricName, "DELTA", "DISTRIBUTION", selector, "default")
+	if err == nil {
+		t.Errorf("Expected error, as distributions should not be suppoted; was suceessful")
 	}
 }
 
@@ -752,8 +736,8 @@ func TestTranslator_GetSDReqForPods_BadPercentile(t *testing.T) {
 	}
 	metricName := "my/custom/metric"
 	selector, _ := labels.Parse("reducer=PERCENTILE_52")
-	_, err := translator.GetSDReqForPods(&v1.PodList{Items: []v1.Pod{pod}}, metricName, "DELTA", selector, "default")
-	expectedError := NewLabelNotAllowedError("Reducer must use a supported percentile (PERCENTILE_05, PERCENTILE_50, PERCENTILE_95, PERCENTILE_99). You used: PERCENTILE_52")
+	_, err := translator.GetSDReqForPods(&v1.PodList{Items: []v1.Pod{pod}}, metricName, "DELTA", "DISTRIBUTION", selector, "default")
+	expectedError := NewLabelNotAllowedError("Specified reducer is not supported: PERCENTILE_52")
 	if *err.(*errors.StatusError) != *expectedError {
 		t.Errorf("Expected status error: %s, but received: %s", expectedError, err)
 	}
@@ -771,7 +755,7 @@ func TestTranslator_GetSDReqForPods_TooManyPercentiles(t *testing.T) {
 	}
 	metricName := "my/custom/metric"
 	selector, _ := labels.Parse("reducer in (PERCENTILE_50,PERCENTILE_99)")
-	_, err := translator.GetSDReqForPods(&v1.PodList{Items: []v1.Pod{pod}}, metricName, "DELTA", selector, "default")
+	_, err := translator.GetSDReqForPods(&v1.PodList{Items: []v1.Pod{pod}}, metricName, "DELTA", "INT64", selector, "default")
 	expectedError := NewLabelNotAllowedError("Reducer must use '=' or '==': You used in")
 	if *err.(*errors.StatusError) != *expectedError {
 		t.Errorf("Expected status error: %s, but received: %s", expectedError, err)
@@ -789,8 +773,8 @@ func TestTranslator_GetSDReqForPods_SingleWithMetricSelector_Distribution(t *tes
 		},
 	}
 	metricName := "my/custom/metric"
-	metricSelector, _ := labels.Parse("metric.labels.custom=test,reducer=PERCENTILE_99")
-	request, err := translator.GetSDReqForPods(&v1.PodList{Items: []v1.Pod{pod}}, metricName, "DELTA", metricSelector, "default")
+	metricSelector, _ := labels.Parse("metric.labels.custom=test,reducer=REDUCE_PERCENTILE_99")
+	request, err := translator.GetSDReqForPods(&v1.PodList{Items: []v1.Pod{pod}}, metricName, "DELTA", "DISTRIBUTION", metricSelector, "default")
 	if err != nil {
 		t.Errorf("Translation error: %s", err)
 	}
@@ -824,8 +808,8 @@ func TestTranslator_GetSDReqForContainers_Single_Distribution(t *testing.T) {
 		},
 	}
 	metricName := "my/custom/metric"
-	selector, _ := labels.Parse("reducer=PERCENTILE_50")
-	request, err := translator.GetSDReqForContainers(&v1.PodList{Items: []v1.Pod{pod}}, metricName, "DELTA", selector, "default")
+	selector, _ := labels.Parse("reducer=REDUCE_PERCENTILE_50")
+	request, err := translator.GetSDReqForContainers(&v1.PodList{Items: []v1.Pod{pod}}, metricName, "DELTA", "DISTRIBUTION", selector, "default")
 	if err != nil {
 		t.Errorf("Translation error: %s", err)
 	}
@@ -858,8 +842,8 @@ func TestTranslator_GetSDReqForContainer_SingleWithMetricSelector_Distribution(t
 		},
 	}
 	metricName := "my/custom/metric"
-	metricSelector, _ := labels.Parse("metric.labels.custom=test,reducer=PERCENTILE_99")
-	request, err := translator.GetSDReqForContainers(&v1.PodList{Items: []v1.Pod{pod}}, metricName, "DELTA", metricSelector, "default")
+	metricSelector, _ := labels.Parse("metric.labels.custom=test,reducer=REDUCE_PERCENTILE_99")
+	request, err := translator.GetSDReqForContainers(&v1.PodList{Items: []v1.Pod{pod}}, metricName, "DELTA", "DISTRIBUTION", metricSelector, "default")
 	if err != nil {
 		t.Errorf("Translation error: %s", err)
 	}
@@ -893,8 +877,8 @@ func TestTranslator_GetSDReqForNodes_Single_Distribution(t *testing.T) {
 		},
 	}
 	metricName := "my/custom/metric"
-	metricSelector, _ := labels.Parse("reducer=PERCENTILE_95")
-	request, err := translator.GetSDReqForNodes(&v1.NodeList{Items: []v1.Node{node}}, metricName, "DELTA", metricSelector)
+	metricSelector, _ := labels.Parse("reducer=REDUCE_PERCENTILE_95")
+	request, err := translator.GetSDReqForNodes(&v1.NodeList{Items: []v1.Node{node}}, metricName, "DELTA", "DISTRIBUTION", metricSelector)
 	if err != nil {
 		t.Errorf("Translation error: %s", err)
 	}
@@ -926,8 +910,8 @@ func TestTranslator_GetSDReqForNodes_SingleWithMetricSelector_Distribution(t *te
 		},
 	}
 	metricName := "my/custom/metric"
-	metricSelector, _ := labels.Parse("metric.labels.custom=test,reducer=PERCENTILE_95")
-	request, err := translator.GetSDReqForNodes(&v1.NodeList{Items: []v1.Node{node}}, metricName, "DELTA", metricSelector)
+	metricSelector, _ := labels.Parse("metric.labels.custom=test,reducer=REDUCE_PERCENTILE_95")
+	request, err := translator.GetSDReqForNodes(&v1.NodeList{Items: []v1.Node{node}}, metricName, "DELTA", "DISTRIBUTION", metricSelector)
 	if err != nil {
 		t.Errorf("Translation error: %s", err)
 	}

--- a/custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go
+++ b/custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go
@@ -753,7 +753,7 @@ func TestTranslator_GetSDReqForPods_BadPercentile(t *testing.T) {
 	metricName := "my/custom/metric"
 	selector, _ := labels.Parse("reducer=PERCENTILE_52")
 	_, err := translator.GetSDReqForPods(&v1.PodList{Items: []v1.Pod{pod}}, metricName, "DELTA", selector, "default")
-	expectedError := NewLabelNotAllowedError("Reducer must use a supported percentile (PERCENTILE_50, PERCENTILE_95, PERCENTILE_99). You used: PERCENTILE_52")
+	expectedError := NewLabelNotAllowedError("Reducer must use a supported percentile (PERCENTILE_05, PERCENTILE_50, PERCENTILE_95, PERCENTILE_99). You used: PERCENTILE_52")
 	if *err.(*errors.StatusError) != *expectedError {
 		t.Errorf("Expected status error: %s, but received: %s", expectedError, err)
 	}

--- a/hack/verify-flags/exceptions.txt
+++ b/hack/verify-flags/exceptions.txt
@@ -8,11 +8,6 @@ custom-metrics-stackdriver-adapter/README.md:       project_id, err := gce.Proje
 custom-metrics-stackdriver-adapter/README.md:     - `namespace_id` and `instance_id` (for **legacy resource model**) are not
 custom-metrics-stackdriver-adapter/README.md:     - `pod_id`, `pod_name`, `namespace_name` can be obtained via downward API.
 custom-metrics-stackdriver-adapter/README.md:     - `project_id`, `zone`, `location`, `cluster_name` - can be obtained by your
-custom-metrics-stackdriver-adapter/cp:			return ":" + timeSeries.Resource.Labels["node_name"], nil
-custom-metrics-stackdriver-adapter/cp:			return timeSeries.Resource.Labels["namespace_name"] + ":" + timeSeries.Resource.Labels["pod_name"], nil
-custom-metrics-stackdriver-adapter/cp:			return timeSeries.Resource.Labels["namespace_name"] + ":" + timeSeries.Resource.Labels["pod_name"], nil
-custom-metrics-stackdriver-adapter/cp:		nodeName := series.Resource.Labels["node_name"]
-custom-metrics-stackdriver-adapter/cp:		return timeSeries.Resource.Labels["pod_id"], nil
 custom-metrics-stackdriver-adapter/examples/direct-to-sd/sd_dummy_exporter.go:		"cluster_name":   clusterName,
 custom-metrics-stackdriver-adapter/examples/direct-to-sd/sd_dummy_exporter.go:		"cluster_name": clusterName,
 custom-metrics-stackdriver-adapter/examples/direct-to-sd/sd_dummy_exporter.go:		"namespace_id": "default",
@@ -59,9 +54,17 @@ custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go:
 custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go:			"AND resource.labels.cluster_name = \"my-cluster\" " +
 custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go:			"AND resource.labels.cluster_name = \"my-cluster\" " +
 custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go:			"AND resource.labels.cluster_name = \"my-cluster\" " +
+custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go:			"AND resource.labels.cluster_name = \"my-cluster\" " +
+custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go:			"AND resource.labels.cluster_name = \"my-cluster\" " +
+custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go:			"AND resource.labels.cluster_name = \"my-cluster\" " +
+custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go:			"AND resource.labels.cluster_name = \"my-cluster\" " +
+custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go:			"AND resource.labels.cluster_name = \"my-cluster\" " +
+custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go:			"AND resource.labels.cluster_name = \"my-cluster\" " +
 custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go:			"AND resource.labels.container_name = \"\" AND resource.labels.pod_id != \"\" " +
 custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go:			"AND resource.labels.node_name = \"my-node-name-1\" " +
 custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go:			"AND resource.labels.node_name = \"my-node-name-1\" " +
+custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go:			"AND resource.labels.node_name = \"my-node-name\" " +
+custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go:			"AND resource.labels.node_name = \"my-node-name\" " +
 custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go:			"AND resource.labels.pod_id != \"machine\"")
 custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go:			"AND resource.labels.pod_id = one_of(\"my-pod-id-1\",\"my-pod-id-2\")").
 custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go:			"AND resource.labels.pod_name = \"my-pod-name\" " +
@@ -69,11 +72,21 @@ custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go:
 custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go:			"AND resource.labels.pod_name = \"my-pod-name\" " +
 custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go:			"AND resource.labels.pod_name = \"my-pod-name\" " +
 custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go:			"AND resource.labels.pod_name = \"my-pod-name\" " +
+custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go:			"AND resource.labels.pod_name = \"my-pod-name\" " +
+custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go:			"AND resource.labels.pod_name = \"my-pod-name\" " +
+custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go:			"AND resource.labels.pod_name = \"my-pod-name\" " +
+custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go:			"AND resource.labels.pod_name = \"my-pod-name\" " +
 custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go:			"AND resource.labels.pod_name = one_of(\"my-pod-name-1\",\"my-pod-name-2\") " +
 custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go:			"AND resource.labels.pod_name = one_of(\"my-pod-name-1\",\"my-pod-name-2\") " +
 custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go:			"AND resource.labels.pod_name = one_of(\"my-pod-name-1\",\"my-pod-name-2\") " +
 custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go:			"AND resource.labels.pod_name = one_of(\"my-pod-name-1\",\"my-pod-name-2\") " +
 custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go:			"AND resource.labels.pod_name = one_of(\"my-pod-name-1\",\"my-pod-name-2\") " +
+custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go:			"AND resource.labels.project_id = \"my-project\" " +
+custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go:			"AND resource.labels.project_id = \"my-project\" " +
+custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go:			"AND resource.labels.project_id = \"my-project\" " +
+custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go:			"AND resource.labels.project_id = \"my-project\" " +
+custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go:			"AND resource.labels.project_id = \"my-project\" " +
+custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go:			"AND resource.labels.project_id = \"my-project\" " +
 custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go:			"AND resource.labels.project_id = \"my-project\" " +
 custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go:			"AND resource.labels.project_id = \"my-project\" " +
 custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go:			"AND resource.labels.project_id = \"my-project\" " +

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -44,6 +44,7 @@ e2e-status-context
 election-namespace
 enable-core-metrics-api
 enable-custom-metrics-api
+enable-distribution-support
 enable-external-metrics-api
 enable-md-yaml
 enable-output-coloring


### PR DESCRIPTION
This PR adds the initial capability to support HPA based on Stackdriver distributions. It uses a special selector to signal that a distribution is intended: `reducer`. This is desired to enable scaling based on measures such as request latency percentiles.

This should allow usage of resources similar to:

```yaml
apiVersion: autoscaling/v2beta1
kind: HorizontalPodAutoscaler
metadata:
  name: productcatalogservice
  namespace: default
spec:
  minReplicas: 1
  maxReplicas: 5
  metrics:
  - external:
      metricName: istio.io|service|server|response_latencies
      metricSelector:
        matchLabels:
          metric.labels.destination_workload_name: productcatalogservice
          reducer: PERCENTILE_99
      targetAverageValue: "2"
    type: External
  scaleTargetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: productcatalogservice
```