### PR TITLE
Utilize hostname when instance/node unavailable.

### DIFF
--- a/prometheus-to-sd/config/gce_config.go
+++ b/prometheus-to-sd/config/gce_config.go
@@ -84,10 +84,17 @@ func GetGceConfig(project, cluster, clusterLocation, zone, node string) (*GceCon
 		}
 	}
 
+	// instance/name endpoint is not available on the GKE metadata server.
+	// Try GCE instance/name endpoint. If error, try instance/hostname.
+	// If instance/hostname, remove domain to replicate instance/name.
 	if node == "" {
 		node, err = gce.InstanceName()
 		if err != nil {
-			return nil, fmt.Errorf("error while getting instance (node) name: %v", err)
+			node, err = gce.Hostname()
+			if err != nil {
+				return nil, fmt.Errorf("error while getting instance (node) name: %v", err)
+			}
+			node = strings.Split(node, ".")[0]
 		}
 	}
 

--- a/prometheus-to-sd/config/gce_config.go
+++ b/prometheus-to-sd/config/gce_config.go
@@ -95,6 +95,7 @@ func GetGceConfig(project, cluster, clusterLocation, zone, node string) (*GceCon
 				return nil, fmt.Errorf("error while getting instance (node) name: %v", err)
 			}
 			node = strings.Split(node, ".")[0]
+			glog.Warningf("using %s as instance/name", node)
 		}
 	}
 


### PR DESCRIPTION
When running in GKE with workload identity enabled, prometheus-to-sd
will enter a crashloop unless you run it with host-networking enabled
which will bypass the GKE metadata server. This solves that issue by
utilizing instance/hostname when instance/name isn't available.

Fixes: #399