### PR TITLE
Missing Scopes in call to DefaultTokenSource()

### DIFF
--- a/prometheus-to-sd/main.go
+++ b/prometheus-to-sd/main.go
@@ -155,7 +155,7 @@ func main() {
 		}
 		glog.Infof("Created a client with the default credentials")
 	} else {
-		ts, err := google.DefaultTokenSource(context.Background(), "")
+		ts, err := google.DefaultTokenSource(context.Background(), "https://www.googleapis.com/auth/cloud-platform")
 		if err != nil {
 			glog.Fatalf("Error creating default token source: %v", err)
 		}


### PR DESCRIPTION
One invocation of google.DefaultTokenSource() is missing the scope
parameter. This results in that particular authentication flow failing
to fetch a token due to an empty set of scopes in the request. This PR
sets a wide scope matching another invocation of a similar method. IAM
should restrict perms further.

fixes: #401