### PR TITLE
Stop talking to kube-controller-manager from kubelet-to-gcm when port is set to 0

### DIFF
--- a/kubelet-to-gcm/Makefile
+++ b/kubelet-to-gcm/Makefile
@@ -15,7 +15,7 @@
 OUT_DIR = build
 PACKAGE = github.com/GoogleCloudPlatform/k8s-stackdriver/kubelet-to-gcm
 PREFIX = staging-k8s.gcr.io
-TAG = 1.3.3
+TAG = 1.3.4
 
 # Rules for building the real image for deployment to gcr.io
 


### PR DESCRIPTION
This isn't really used and occassionally causes problems. Leaving the functionality for now to make rolling back easier.