### PR TITLE
Prevent invalid timestamps in page_fault_count metric

### DIFF
--- a/kubelet-to-gcm/Makefile
+++ b/kubelet-to-gcm/Makefile
@@ -15,7 +15,7 @@
 OUT_DIR = build
 PACKAGE = github.com/GoogleCloudPlatform/k8s-stackdriver/kubelet-to-gcm
 PREFIX = staging-k8s.gcr.io
-TAG = 1.3.4
+TAG = 1.3.5
 
 # Rules for building the real image for deployment to gcr.io
 

--- a/kubelet-to-gcm/monitor/kubelet/translate.go
+++ b/kubelet-to-gcm/monitor/kubelet/translate.go
@@ -519,7 +519,8 @@ func translateMemory(memory *stats.MemoryStats, tsFactory *timeSeriesFactory, st
 		return nil, fmt.Errorf("Memory information missing.")
 	}
 
-	if pageFaultsMD != nil {
+	// Only send page fault metric if start time is before current time. Right after container is started, kubelet can return start time == end time. This doesn't seem to happen with other metrics.
+	if pageFaultsMD != nil && memory.Time.Time.After(startTime) {
 		if memory.MajorPageFaults == nil {
 			return nil, fmt.Errorf("MajorPageFaults missing in MemoryStats %v", memory)
 		}


### PR DESCRIPTION
Right after container is started, kubelet returns time == start_time for
that metric, which causes Monitoring API to return 400 error.