### PR TITLE
Rebase sd-dummy-exporter to distroless

### DIFF
--- a/custom-metrics-stackdriver-adapter/examples/direct-to-sd/Dockerfile
+++ b/custom-metrics-stackdriver-adapter/examples/direct-to-sd/Dockerfile
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/google-containers/debian-base-amd64:v1.0.1
+FROM golang:1.15.11
+ADD . /go/src/sd-dummy-exporter
+RUN go get cloud.google.com/go/compute/metadata
+RUN go get golang.org/x/oauth2
+RUN go get cloud.google.com/go/monitoring/apiv3
+RUN CGO_ENABLED=0 GOOS=linux go install sd-dummy-exporter
 
-ADD sd_dummy_exporter sd_dummy_exporter
+FROM gcr.io/distroless/static:latest
+COPY --from=0 /go/bin/sd-dummy-exporter .
 
-RUN chmod +x sd_dummy_exporter
-
-RUN clean-install ca-certificates
-
-USER 65534:65534

--- a/custom-metrics-stackdriver-adapter/examples/direct-to-sd/Makefile
+++ b/custom-metrics-stackdriver-adapter/examples/direct-to-sd/Makefile
@@ -1,16 +1,8 @@
-TAG = v0.2.1
-PREFIX = staging-k8s.gcr.io
+TAG = v0.3.0
+PREFIX = gcr.io/google-samples
 
-build: sd_dummy_exporter
-
-sd_dummy_exporter: sd_dummy_exporter.go
-	go build -a -o sd_dummy_exporter sd_dummy_exporter.go
-
-docker: sd_dummy_exporter
+docker: 
 	docker build --pull -t ${PREFIX}/sd-dummy-exporter:$(TAG) .
 
 push: docker
 	gcloud docker -- push ${PREFIX}/sd-dummy-exporter:$(TAG)
-
-clean:
-	rm -rf sd_dummy_exporter

--- a/custom-metrics-stackdriver-adapter/examples/direct-to-sd/custom-metrics-sd.yaml
+++ b/custom-metrics-stackdriver-adapter/examples/direct-to-sd/custom-metrics-sd.yaml
@@ -16,11 +16,19 @@ spec:
         run: custom-metric-sd
     spec:
       containers:
-      - command:
-        - /bin/sh
-        - -c
-        - ./sd_dummy_exporter --metric-name=foo --metric-labels=bar=1 --metric-value=40 --use-new-resource-model --use-old-resource-model --pod-id=$(POD_ID) --pod-name=$(POD_NAME) --namespace=$(NAMESPACE)
-        image: gcr.io/google-containers/sd-dummy-exporter:v0.2.0
+      - command: ["./sd-dummy-exporter"]
+        args:
+        - --use-new-resource-model=true
+        - --use-old-resource-model=false
+        - --metric-name=foo
+        - --metric-labels=bar=1
+        - --metric-value=40
+        - --use-new-resource-model
+        - --use-old-resource-model
+        - --pod-id=$(POD_ID)
+        - --pod-name=$(POD_NAME)
+        - --namespace=$(NAMESPACE)                
+        image: gcr.io/google-samples/sd-dummy-exporter:v0.3.0        
         name: sd-dummy-exporter
         resources:
           requests:


### PR DESCRIPTION
Why?
This fixes some CVE issues [1] with
gcr.io/google-containers/sd-dummy-exporter:v0.2.0, which is based on
alpine:latest.

[1] CVE-2018-12020 CVE-2017-12837 CVE-2018-15688 CVE-2017-10140
CVE-2017-7526 CVE-2018-6913 CVE-2018-16864 CVE-2017-12883 CVE-2018-12015
CVE-2018-16865

I also pushed the new image to gcr.io/ to gcr.io/google-samples/ 