### PR TITLE
Rebase prometheus-dummy-exporter on distroless

### DIFF
--- a/custom-metrics-stackdriver-adapter/examples/prometheus-to-sd/Dockerfile
+++ b/custom-metrics-stackdriver-adapter/examples/prometheus-to-sd/Dockerfile
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/google-containers/debian-base-amd64:v1.0.1
+FROM golang:1.12.5
+ADD . /go/src/prometheus-dummy-exporter
+RUN go get github.com/prometheus/client_golang/prometheus
+RUN CGO_ENABLED=0 GOOS=linux go install prometheus-dummy-exporter
 
-ADD prometheus_dummy_exporter prometheus_dummy_exporter
-
-RUN chmod +x prometheus_dummy_exporter
-
-RUN clean-install ca-certificates
-
-USER 65534:65534
+FROM gcr.io/distroless/static:latest
+COPY --from=0 /go/bin/prometheus-dummy-exporter .

--- a/custom-metrics-stackdriver-adapter/examples/prometheus-to-sd/Makefile
+++ b/custom-metrics-stackdriver-adapter/examples/prometheus-to-sd/Makefile
@@ -1,16 +1,8 @@
-TAG = v0.1.1
-PREFIX = staging-k8s.gcr.io
+TAG = v0.2.0
+PREFIX = gcr.io/google-samples
 
-build: prometheus_dummy_exporter
-
-prometheus_dummy_exporter: prometheus_dummy_exporter.go
-	go build -a -o prometheus_dummy_exporter prometheus_dummy_exporter.go
-
-docker: prometheus_dummy_exporter
+docker:
 	docker build --pull -t ${PREFIX}/prometheus-dummy-exporter:$(TAG) .
 
 push: docker
 	gcloud docker -- push ${PREFIX}/prometheus-dummy-exporter:$(TAG)
-
-clean:
-	rm -rf prometheus_dummy_exporter

--- a/custom-metrics-stackdriver-adapter/examples/prometheus-to-sd/README.md
+++ b/custom-metrics-stackdriver-adapter/examples/prometheus-to-sd/README.md
@@ -143,7 +143,7 @@ Make sure that:
 * the HPA config has the right scaling target
 ```yaml
 scaleTargetRef:
-    apiVersion: apps/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: <deployment-name>
 ```
@@ -152,8 +152,11 @@ scaleTargetRef:
 metrics:
   - type: Pods
     pods:
-      metricName: <metric-name>
-      targetAverageValue: <target-value>
+      metric:
+        name: <metric-name>
+      target:
+        type: AverageValue
+        averageValue:  <target-value>
 ```
 
 

--- a/custom-metrics-stackdriver-adapter/examples/prometheus-to-sd/custom-metrics-prometheus-sd.yaml
+++ b/custom-metrics-stackdriver-adapter/examples/prometheus-to-sd/custom-metrics-prometheus-sd.yaml
@@ -16,11 +16,12 @@ spec:
         run: custom-metric-prometheus-sd
     spec:
       containers:
-      - command:
-        - /bin/sh
-        - -c
-        - ./prometheus_dummy_exporter --metric-name=foo --metric-value=40 --port=8080
-        image: gcr.io/google-containers/prometheus-dummy-exporter:v0.1.0
+      - command: ["./prometheus-dummy-exporter"]
+        args:
+        - --metric-name=foo
+        - --metric-value=40
+        - --port=8080
+        image: gcr.io/google-samples/prometheus-dummy-exporter:v0.2.0
         name: prometheus-dummy-exporter
         resources:
           requests:
@@ -44,14 +45,14 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
 ---
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: custom-metric-prometheus-sd
   namespace: default
 spec:
   scaleTargetRef:
-    apiVersion: apps/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: custom-metric-prometheus-sd
   minReplicas: 1
@@ -59,7 +60,10 @@ spec:
   metrics:
   - type: Pods
     pods:
-      metricName: foo
-      targetAverageValue: 20
+      metric:
+        name: foo
+      target:
+        type: AverageValue
+        averageValue: 20
 
  

--- a/custom-metrics-stackdriver-adapter/examples/prometheus-to-sd/prometheus_dummy_exporter.go
+++ b/custom-metrics-stackdriver-adapter/examples/prometheus-to-sd/prometheus_dummy_exporter.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 // Prometheus Dummy Exporter is a testing utility that exposes a prometheus format metric of constant value.
@@ -43,7 +44,7 @@ func main() {
 	prometheus.MustRegister(metric)
 	metric.Set(float64(*metricValue))
 
-	http.Handle("/metrics", prometheus.Handler())
+	http.Handle("/metrics", promhttp.Handler())
 	log.Printf("Starting to listen on :%d", *port)
 	err := http.ListenAndServe(fmt.Sprintf(":%d", *port), nil)
 	log.Fatalf("Failed to start serving metrics: %v", err)


### PR DESCRIPTION
This fixes some CVE issues [1] found in
gcr.io/google-containers/prometheus-dummy-exporter:v0.1.0, which is
based on alpine:latest

[1] CVE-2017-12883 CVE-2017-10140 CVE-2018-16865 CVE-2018-6913
CVE-2018-12015 CVE-2018-12020 CVE-2017-7526 CVE-2018-16864
CVE-2017-12837 CVE-2018-15688

Side changes: I updated some files to use newer APIs