### PR TITLE
Refactor monitored_resource_factory.go

### DIFF
--- a/event-exporter/sinks/stackdriver/log_entry_factory.go
+++ b/event-exporter/sinks/stackdriver/log_entry_factory.go
@@ -43,6 +43,7 @@ var (
 	}
 )
 
+// Constructs a log entry from either an event or a message.
 type sdLogEntryFactory struct {
 	clock           clock.Clock
 	encoder         runtime.Encoder

--- a/event-exporter/sinks/stackdriver/monitored_resource_factory_config.go
+++ b/event-exporter/sinks/stackdriver/monitored_resource_factory_config.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 )
 
+// Provides configurations to the `monitoredResourceFactory`.
 type monitoredResourceFactoryConfig struct {
 	resourceModel resourceModelVersion
 	clusterName   string

--- a/event-exporter/sinks/stackdriver/monitored_resource_factory_test.go
+++ b/event-exporter/sinks/stackdriver/monitored_resource_factory_test.go
@@ -120,7 +120,7 @@ func TestDefaultMonitoredResource(t *testing.T) {
 
 	for _, test := range tests {
 		factory := newMonitoredResourceFactory(test.config)
-		monitoredResource := factory.defaultMonitoredResource()
+		monitoredResource := factory.defaultResource
 
 		if !reflect.DeepEqual(*monitoredResource, *test.wanted) {
 			t.Errorf("Wrong monitored resource from event\ngot:\n%swanted:\n%s", stringify(monitoredResource), stringify(test.wanted))

--- a/event-exporter/sinks/stackdriver/sink.go
+++ b/event-exporter/sinks/stackdriver/sink.go
@@ -45,6 +45,7 @@ var (
 	)
 )
 
+// sdSink satisfies sinks.Sink interface.
 type sdSink struct {
 	logEntryChannel   chan *sd.LogEntry
 	config            *sdSinkConfig
@@ -117,11 +118,13 @@ func (s *sdSink) OnDelete(*corev1.Event) {
 	// Nothing to do here
 }
 
+// OnList logs a message indicating that the Event Exporter starts upon
+// receiving the first list of events.
 func (s *sdSink) OnList(list *corev1.EventList) {
 	if s.beforeFirstList {
 		entry := s.logEntryFactory.FromMessage("Event exporter started watching. " +
 			"Some events may have been lost up to this point.")
-		s.writer.Write([]*sd.LogEntry{entry}, s.logName, s.sdResourceFactory.defaultMonitoredResource())
+		s.writer.Write([]*sd.LogEntry{entry}, s.logName, s.sdResourceFactory.defaultResource)
 		s.beforeFirstList = false
 	}
 }
@@ -162,7 +165,7 @@ func (s *sdSink) flushBuffer() {
 func (s *sdSink) sendEntries(entries []*sd.LogEntry) {
 	glog.V(4).Infof("Sending %d entries to Stackdriver", len(entries))
 
-	written := s.writer.Write(entries, s.logName, s.sdResourceFactory.defaultMonitoredResource())
+	written := s.writer.Write(entries, s.logName, s.sdResourceFactory.defaultResource)
 	successfullySentEntryCount.Add(float64(written))
 
 	<-s.concurrencyChannel

--- a/event-exporter/sinks/stackdriver/sink_config.go
+++ b/event-exporter/sinks/stackdriver/sink_config.go
@@ -41,6 +41,7 @@ type sdSinkConfig struct {
 	Endpoint       string
 }
 
+// Provides Stackdriver sink default values for GCE instances.
 func newGceSdSinkConfig() (*sdSinkConfig, error) {
 	if !metadata.OnGCE() {
 		return nil, errors.New("not running on GCE, which is not supported for Stackdriver sink")

--- a/event-exporter/sinks/stackdriver/sink_factory.go
+++ b/event-exporter/sinks/stackdriver/sink_factory.go
@@ -39,7 +39,7 @@ type sdSinkFactory struct {
 	endpoint             *string
 }
 
-// NewSdSinkFactory creates a new Stackdriver sink factory
+// NewSdSinkFactory creates a new Stackdriver sink factory.
 func NewSdSinkFactory() sinks.SinkFactory {
 	fs := flag.NewFlagSet("stackdriver", flag.ContinueOnError)
 	return &sdSinkFactory{
@@ -57,6 +57,7 @@ func NewSdSinkFactory() sinks.SinkFactory {
 	}
 }
 
+// CreateNew creates a new Stackdriver sink.
 func (f *sdSinkFactory) CreateNew(opts []string) (sinks.Sink, error) {
 	err := f.flagSet.Parse(opts)
 	if err != nil {

--- a/event-exporter/sinks/stackdriver/writer.go
+++ b/event-exporter/sinks/stackdriver/writer.go
@@ -56,6 +56,8 @@ func newSdWriter(service *sd.Service) sdWriter {
 	}
 }
 
+// Writer writes log entries to Stackdriver. It retries writing logs forever
+// unless the API returns BadRequest error.
 func (w sdWriterImpl) Write(entries []*sd.LogEntry, logName string, resource *sd.MonitoredResource) int {
 	req := &sd.WriteLogEntriesRequest{
 		Entries:  entries,

--- a/event-exporter/watchers/events/handler.go
+++ b/event-exporter/watchers/events/handler.go
@@ -31,6 +31,7 @@ type EventHandler interface {
 	OnDelete(*corev1.Event)
 }
 
+// eventHandlerWrapper is a wrapper of EventHandler for testing proposes.
 type eventHandlerWrapper struct {
 	handler EventHandler
 }
@@ -78,6 +79,7 @@ func (c *eventHandlerWrapper) OnDelete(obj interface{}) {
 	c.handler.OnDelete(event)
 }
 
+// Coverts an object of any type to a corev1.Event if applicable.
 func (c *eventHandlerWrapper) convert(obj interface{}) (*corev1.Event, bool) {
 	if event, ok := obj.(*corev1.Event); ok {
 		return event, true

--- a/event-exporter/watchers/events/watcher.go
+++ b/event-exporter/watchers/events/watcher.go
@@ -65,6 +65,7 @@ type EventWatcherConfig struct {
 // NewEventWatcher create a new watcher that only watches the events resource.
 func NewEventWatcher(client kubernetes.Interface, config *EventWatcherConfig) watchers.Watcher {
 	return watchers.NewWatcher(&watchers.WatcherConfig{
+		// List and watch events in all namespaces.
 		ListerWatcher: &cache.ListWatch{
 			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
 				list, err := client.CoreV1().Events(meta_v1.NamespaceAll).List(options)

--- a/event-exporter/watchers/watcher.go
+++ b/event-exporter/watchers/watcher.go
@@ -36,6 +36,7 @@ type Watcher interface {
 	Run(stopCh <-chan struct{})
 }
 
+// watcher satisfies the Watcher interface.
 type watcher struct {
 	reflector *cache.Reflector
 }


### PR DESCRIPTION
Refactor monitored_resource_factory.go by removing redundant `config`
field and renaming existing `labels` field.

Also add comments in various files to improve readability.

Tested: make test