### PR TITLE
Update ClusterRoleBinding API version

### DIFF
--- a/custom-metrics-stackdriver-adapter/adapter-beta.yaml
+++ b/custom-metrics-stackdriver-adapter/adapter-beta.yaml
@@ -36,7 +36,7 @@ subjects:
   name: custom-metrics-stackdriver-adapter
   namespace: custom-metrics
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: custom-metrics-resource-reader

--- a/custom-metrics-stackdriver-adapter/deploy/production/adapter.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/production/adapter.yaml
@@ -36,7 +36,7 @@ subjects:
   name: custom-metrics-stackdriver-adapter
   namespace: custom-metrics
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: custom-metrics-resource-reader

--- a/custom-metrics-stackdriver-adapter/deploy/production/adapter_new_resource_model.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/production/adapter_new_resource_model.yaml
@@ -36,7 +36,7 @@ subjects:
   name: custom-metrics-stackdriver-adapter
   namespace: custom-metrics
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: custom-metrics-resource-reader

--- a/custom-metrics-stackdriver-adapter/deploy/staging/adapter_new_resource_model.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/staging/adapter_new_resource_model.yaml
@@ -40,7 +40,7 @@ subjects:
   name: custom-metrics-stackdriver-adapter
   namespace: custom-metrics
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: custom-metrics-resource-reader

--- a/custom-metrics-stackdriver-adapter/deploy/test/adapter_new_resource_model_with_core_metrics.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/test/adapter_new_resource_model_with_core_metrics.yaml
@@ -40,7 +40,7 @@ subjects:
   name: custom-metrics-stackdriver-adapter
   namespace: custom-metrics
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: custom-metrics-resource-reader

--- a/custom-metrics-stackdriver-adapter/vendor/k8s.io/apiserver/pkg/apis/audit/validation/validation.go
+++ b/custom-metrics-stackdriver-adapter/vendor/k8s.io/apiserver/pkg/apis/audit/validation/validation.go
@@ -101,7 +101,7 @@ func validateResources(groupResources []audit.GroupResources, fldPath *field.Pat
 		if len(groupResource.Group) != 0 {
 			// Group names must be lower case and be valid DNS subdomains.
 			// reference: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
-			// an error is returned for group name like rbac.authorization.k8s.io/v1beta1
+			// an error is returned for group name like rbac.authorization.k8s.io/v1
 			// rbac.authorization.k8s.io is the valid one
 			if msgs := validation.NameIsDNSSubdomain(groupResource.Group, false); len(msgs) != 0 {
 				allErrs = append(allErrs, field.Invalid(fldPath.Child("group"), groupResource.Group, strings.Join(msgs, ",")))

--- a/event-exporter/example/event-exporter.yaml
+++ b/event-exporter/example/event-exporter.yaml
@@ -17,7 +17,7 @@ kind: ServiceAccount
 metadata:
   name: event-exporter-sa
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: event-exporter-rb-example


### PR DESCRIPTION
A few resources were still using v1beta1 which will
be deprecated in Kube 1.22.  This change updates all
occurrences to v1.

Signed-off-by: Gari Singh <gari.r.singh@gmail.com>