### PR TITLE
Upgrade deprecated K8s resources

### DIFF
--- a/custom-metrics-stackdriver-adapter/adapter-beta.yaml
+++ b/custom-metrics-stackdriver-adapter/adapter-beta.yaml
@@ -36,7 +36,7 @@ subjects:
   name: custom-metrics-stackdriver-adapter
   namespace: custom-metrics
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: custom-metrics-resource-reader
@@ -105,7 +105,7 @@ spec:
     k8s-app: custom-metrics-stackdriver-adapter
   type: ClusterIP
 ---
-apiVersion: apiregistration.k8s.io/v1beta1
+apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
   name: v1beta1.custom.metrics.k8s.io

--- a/custom-metrics-stackdriver-adapter/deploy/production/adapter.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/production/adapter.yaml
@@ -36,7 +36,7 @@ subjects:
   name: custom-metrics-stackdriver-adapter
   namespace: custom-metrics
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: custom-metrics-resource-reader

--- a/custom-metrics-stackdriver-adapter/deploy/production/adapter_new_resource_model.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/production/adapter_new_resource_model.yaml
@@ -36,7 +36,7 @@ subjects:
   name: custom-metrics-stackdriver-adapter
   namespace: custom-metrics
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: custom-metrics-resource-reader

--- a/custom-metrics-stackdriver-adapter/deploy/staging/adapter_new_resource_model.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/staging/adapter_new_resource_model.yaml
@@ -40,7 +40,7 @@ subjects:
   name: custom-metrics-stackdriver-adapter
   namespace: custom-metrics
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: custom-metrics-resource-reader

--- a/custom-metrics-stackdriver-adapter/deploy/test/adapter_new_resource_model_with_core_metrics.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/test/adapter_new_resource_model_with_core_metrics.yaml
@@ -40,7 +40,7 @@ subjects:
   name: custom-metrics-stackdriver-adapter
   namespace: custom-metrics
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: custom-metrics-resource-reader

--- a/custom-metrics-stackdriver-adapter/examples/direct-to-sd/README.md
+++ b/custom-metrics-stackdriver-adapter/examples/direct-to-sd/README.md
@@ -129,7 +129,7 @@ Make sure that:
 * the HPA config has the right scaling target
 ```yaml
 scaleTargetRef:
-    apiVersion: apps/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: <deployment-name>
 ```

--- a/custom-metrics-stackdriver-adapter/examples/direct-to-sd/custom-metrics-sd.yaml
+++ b/custom-metrics-stackdriver-adapter/examples/direct-to-sd/custom-metrics-sd.yaml
@@ -57,7 +57,7 @@ metadata:
   namespace: default
 spec:
   scaleTargetRef:
-    apiVersion: apps/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: custom-metric-sd
   minReplicas: 1

--- a/event-exporter/example/event-exporter.yaml
+++ b/event-exporter/example/event-exporter.yaml
@@ -17,7 +17,7 @@ kind: ServiceAccount
 metadata:
   name: event-exporter-sa
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: event-exporter-rb-example
@@ -30,7 +30,7 @@ subjects:
     name: event-exporter-sa
     namespace: default
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: event-exporter-deployment


### PR DESCRIPTION
rbac.authorization.k8s.io/v1beta1 ClusterRole, ClusterRoleBinding, Role,
and RoleBinding are deprecated in v1.17+, unavailable in v1.22+; use
rbac.authorization.k8s.io/v1 available since 1.8

apiregistration.k8s.io/v1beta1 APIService is deprecated in v1.19+,
unavailable in v1.22+; use apiregistration.k8s.io/v1 APIService
available since 1.10

apps/v1beta1 of Deployment are no longer served as of v1.16. Use apps/v1
available since 1.9.

See https://kubernetes.io/docs/reference/using-api/deprecation-guide/