### PR TITLE
Enable fallback to k8s_container metrics

### DIFF
--- a/custom-metrics-stackdriver-adapter/deploy/production/adapter_new_resource_model.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/production/adapter_new_resource_model.yaml
@@ -78,6 +78,7 @@ spec:
         command:
         - /adapter
         - --use-new-resource-model=true
+        - --fallback-for-container-metrics=true
         resources:
           limits:
             cpu: 250m

--- a/custom-metrics-stackdriver-adapter/deploy/staging/adapter_new_resource_model.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/staging/adapter_new_resource_model.yaml
@@ -82,6 +82,7 @@ spec:
         command:
         - /adapter
         - --use-new-resource-model=true
+        - --fallback-for-container-metrics=true
         resources:
           limits:
             cpu: 250m


### PR DESCRIPTION
The current metrics adapter deployment does not
currently set the fallback-for-container-metrics
flag.  In order to work with GKE workload metrics,
this needs to be set to true.

Signed-off-by: Gari Singh <gari.r.singh@gmail.com>