### PR TITLE
Upgrade rbac.authorization.k8s.io API version to v1

### DIFF
--- a/custom-metrics-stackdriver-adapter/adapter-beta.yaml
+++ b/custom-metrics-stackdriver-adapter/adapter-beta.yaml
@@ -36,7 +36,7 @@ subjects:
   name: custom-metrics-stackdriver-adapter
   namespace: custom-metrics
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: custom-metrics-resource-reader

--- a/custom-metrics-stackdriver-adapter/deploy/production/adapter.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/production/adapter.yaml
@@ -36,7 +36,7 @@ subjects:
   name: custom-metrics-stackdriver-adapter
   namespace: custom-metrics
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: custom-metrics-resource-reader

--- a/custom-metrics-stackdriver-adapter/deploy/production/adapter_new_resource_model.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/production/adapter_new_resource_model.yaml
@@ -36,7 +36,7 @@ subjects:
   name: custom-metrics-stackdriver-adapter
   namespace: custom-metrics
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: custom-metrics-resource-reader

--- a/custom-metrics-stackdriver-adapter/deploy/staging/adapter_new_resource_model.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/staging/adapter_new_resource_model.yaml
@@ -40,7 +40,7 @@ subjects:
   name: custom-metrics-stackdriver-adapter
   namespace: custom-metrics
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: custom-metrics-resource-reader

--- a/custom-metrics-stackdriver-adapter/deploy/test/adapter_new_resource_model_with_core_metrics.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/test/adapter_new_resource_model_with_core_metrics.yaml
@@ -40,7 +40,7 @@ subjects:
   name: custom-metrics-stackdriver-adapter
   namespace: custom-metrics
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: custom-metrics-resource-reader

--- a/event-exporter/example/event-exporter.yaml
+++ b/event-exporter/example/event-exporter.yaml
@@ -17,7 +17,7 @@ kind: ServiceAccount
 metadata:
   name: event-exporter-sa
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: event-exporter-rb-example


### PR DESCRIPTION
Starting from Kubernetes v1.22, authorization.k8s.io/v1beta1 version of
SubjectAccessReview, LocalSubjectAccessReview, SelfSubjectAccessReview
is no longer served.

Refer to the link below for more details.
https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22