### PR TITLE
Increment received_entry_count during list.

### DIFF
--- a/event-exporter/sinks/stackdriver/sink.go
+++ b/event-exporter/sinks/stackdriver/sink.go
@@ -114,6 +114,8 @@ func (s *sdSink) OnDelete(*corev1.Event) {
 // receiving the first list of events.
 func (s *sdSink) OnList(list *corev1.EventList) {
 	if s.beforeFirstList {
+		receivedEntryCount.Inc()
+		
 		entry := s.logEntryFactory.FromMessage("Event exporter started watching. " +
 			"Some events may have been lost up to this point.")
 		s.writer.Write([]*sd.LogEntry{entry}, s.logName, s.sdResourceFactory.defaultResource)

--- a/event-exporter/sinks/stackdriver/sink_test.go
+++ b/event-exporter/sinks/stackdriver/sink_test.go
@@ -28,14 +28,13 @@ import (
 )
 
 type fakeSdWriter struct {
-	writeFunc func([]*sd.LogEntry, string, *sd.MonitoredResource) int
+	writeFunc func([]*sd.LogEntry, string, *sd.MonitoredResource)
 }
 
-func (w *fakeSdWriter) Write(entries []*sd.LogEntry, logName string, resource *sd.MonitoredResource) int {
+func (w *fakeSdWriter) Write(entries []*sd.LogEntry, logName string, resource *sd.MonitoredResource) {
 	if w.writeFunc != nil {
-		return w.writeFunc(entries, logName, resource)
+		w.writeFunc(entries, logName, resource)
 	}
-	return 0
 }
 
 const (
@@ -165,12 +164,11 @@ func createSinkWith(params map[string]interface{}) (c *sdSinkConfig, s *sdSink, 
 	c = createConfig(params)
 	q = make(chan struct{}, 2*c.MaxConcurrency)
 	w := &fakeSdWriter{
-		writeFunc: func([]*sd.LogEntry, string, *sd.MonitoredResource) int {
+		writeFunc: func([]*sd.LogEntry, string, *sd.MonitoredResource) {
 			q <- struct{}{}
 			if v, ok := params[blockingParamName]; ok && v.(bool) {
 				<-done
 			}
-			return 0
 		},
 	}
 


### PR DESCRIPTION
Event exporter writes a log entry to Cloud Logging during list by calling
writer.Write(). This entry is not currently counted in the metric
received_entry_count.