### PR TITLE
Bump event-exporter version to 0.3.7

### DIFF
--- a/event-exporter/Makefile
+++ b/event-exporter/Makefile
@@ -20,7 +20,7 @@ ALL_ARCH=amd64 arm64
 IMAGE_NAME = event-exporter
 
 PREFIX ?= staging-k8s.gcr.io
-TAG ?= v0.3.6
+TAG ?= v0.3.7
 
 IMAGE=$(PREFIX)/$(IMAGE_NAME)
 


### PR DESCRIPTION
The new version include increment metric received_entry_count during
list.