### PR TITLE
Improve memory usage of event-exporter

### DIFF
--- a/event-exporter/Makefile
+++ b/event-exporter/Makefile
@@ -20,7 +20,7 @@ ALL_ARCH=amd64 arm64
 IMAGE_NAME = event-exporter
 
 PREFIX ?= staging-k8s.gcr.io
-TAG ?= v0.3.10
+TAG ?= v0.4.0
 
 IMAGE=$(PREFIX)/$(IMAGE_NAME)
 

--- a/event-exporter/watchers/events/watcher.go
+++ b/event-exporter/watchers/events/watcher.go
@@ -69,6 +69,9 @@ func NewEventWatcher(client kubernetes.Interface, config *EventWatcherConfig) wa
 		// List and watch events in all namespaces.
 		ListerWatcher: &cache.ListWatch{
 			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
+				// Only return 1 item to help Reflector retrieve ResourceVersion to reestablish
+				// Watch.
+				options.Limit = 1
 				list, err := client.CoreV1().Events(meta_v1.NamespaceAll).List(context.TODO(), options)
 				if err == nil {
 					config.OnList(list)

--- a/event-exporter/watchers/storage.go
+++ b/event-exporter/watchers/storage.go
@@ -48,33 +48,16 @@ type watcherStore struct {
 }
 
 func (s *watcherStore) Add(obj interface{}) error {
-	if err := s.Store.Add(obj); err != nil {
-		return err
-	}
 	s.handler.OnAdd(obj)
 	return nil
 }
 
 func (s *watcherStore) Update(obj interface{}) error {
-	oldObj, ok, err := s.Store.Get(obj)
-	if err != nil {
-		return err
-	}
-	if !ok {
-		oldObj = nil
-	}
-
-	if err = s.Store.Update(obj); err != nil {
-		return err
-	}
-	s.handler.OnUpdate(oldObj, obj)
+	s.handler.OnUpdate(nil, obj)
 	return nil
 }
 
 func (s *watcherStore) Delete(obj interface{}) error {
-	if err := s.Store.Delete(obj); err != nil {
-		return err
-	}
 	s.handler.OnDelete(obj)
 	return nil
 }


### PR DESCRIPTION
* event-exporter is a single replica deployment on user nodes. It currently consumes a significant amount of memory for large clusters (e.g., 800MB for 5k node cluster, 3.5 GB for 15k node cluster).
* To improve memory usage, we no longer store any watched events in memory and we only store a limited (1 item)  amount of listed events to assist with Watch. 
* After the improvement, memory is < 25 MB and does not increase with the number of nodes or events (e.g., 17 MB in 100 node cluster,  19 MB in 5k node cluster, 20 MB in 15k node cluster).
* The improvement does not change CPU usage and logging completeness.

See details in the design doc: https://docs.google.com/document/d/1i5v0N5YdT6nPXA4Uv7Ia6pDCzLONY_X85V7RWfpdHtM/edit?usp=sharing&resourcekey=0-oW6Lg-3i71XewhXI6kUtPA
