### PR TITLE
Increase factor and count of record_latency_seconds.

### DIFF
--- a/event-exporter/sinks/stackdriver/metrics.go
+++ b/event-exporter/sinks/stackdriver/metrics.go
@@ -36,10 +36,11 @@ var (
 
 	recordLatency = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
-			Name:    "records_latency_seconds",
-			Help:    "Log entry latency between log timestamp and delivery to StackDriver.",
+			Name:      "records_latency_seconds",
+			Help:      "Log entry latency between log timestamp and delivery to StackDriver.",
 			Subsystem: "stackdriver_sink",
-			Buckets: prometheus.ExponentialBuckets(2, 1.4, 13),
+			// Highest bucket start at 2 sec * 1.5^19 = 4433.68 sec
+			Buckets: prometheus.ExponentialBuckets(2, 1.5, 20),
 		},
 	)
 )


### PR DESCRIPTION
Currently 99.9% latency reaches 113.388 which is the start
of the highest bucket
(https://screenshot.googleplex.com/DoW7T2fG3VZiJiq). Slightly increase bucket size and add more buckets so that we can distribute data points with higher values in different buckets.