### PR TITLE
[Enhance] Update autoscaling api version to v2 in prometheus example

### DIFF
--- a/custom-metrics-stackdriver-adapter/examples/direct-to-sd/custom-metrics-sd.yaml
+++ b/custom-metrics-stackdriver-adapter/examples/direct-to-sd/custom-metrics-sd.yaml
@@ -50,14 +50,14 @@ spec:
                 apiVersion: v1
                 fieldPath: metadata.namespace
 ---
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: custom-metric-sd
   namespace: default
 spec:
   scaleTargetRef:
-    apiVersion: apps/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: custom-metric-sd
   minReplicas: 1

--- a/custom-metrics-stackdriver-adapter/examples/prometheus-to-sd/custom-metrics-prometheus-sd.yaml
+++ b/custom-metrics-stackdriver-adapter/examples/prometheus-to-sd/custom-metrics-prometheus-sd.yaml
@@ -45,7 +45,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
 ---
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: custom-metric-prometheus-sd


### PR DESCRIPTION
Provided that `autoscaling/v2beta2` will be deprecated since `Kubernetes v1.26`, and `autoscaling/v2` version has all the features needed in the example. We change the HPA api versions to `autoscaling/v2` in examples.

According to the Kubernetes [doc](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#scaling-on-custom-metrics), scaling on custom metrics feature after _Kubernetes v1.23 Stable_. Therefore, from my perspective, updating the HPA api version in the example to use `autoscaling/v2` should be sufficient.