### PR TITLE
Update Custom Metrics Stackdriver Adapter Examples

### DIFF
--- a/custom-metrics-stackdriver-adapter/examples/direct-to-sd/custom-metrics-sd.yaml
+++ b/custom-metrics-stackdriver-adapter/examples/direct-to-sd/custom-metrics-sd.yaml
@@ -16,7 +16,7 @@ spec:
         run: custom-metric-sd
     spec:
       containers:
-      - command: ["./sd-dummy-exporter"]
+      - command: ["./direct-to-sd"]
         args:
         - --use-new-resource-model=true
         - --use-old-resource-model=false
@@ -65,7 +65,10 @@ spec:
   metrics:
   - type: Pods
     pods:
-      metricName: foo
-      targetAverageValue: 20
+      metric:
+        name: foo
+      target:
+        type: AverageValue
+        averageValue: 20
 
  

--- a/custom-metrics-stackdriver-adapter/examples/prometheus-to-sd/custom-metrics-prometheus-sd.yaml
+++ b/custom-metrics-stackdriver-adapter/examples/prometheus-to-sd/custom-metrics-prometheus-sd.yaml
@@ -16,7 +16,7 @@ spec:
         run: custom-metric-prometheus-sd
     spec:
       containers:
-      - command: ["./prometheus-dummy-exporter"]
+      - command: ["./prometheus-to-sd"]
         args:
         - --metric-name=foo
         - --metric-value=40


### PR DESCRIPTION
1. Recently due to an upgrade on the google-examples repo (https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/pull/369), the usages of the example images have been changed, and we just need to update the command to match the new executable file built in the image to make it work again.
2. In `autoscaling/v2`, `metricName` is no longer supported

Please take a look when you get a chance, thanks @laoj2