### PR TITLE
Fix autoscaling v2 attribute

### DIFF
--- a/custom-metrics-stackdriver-adapter/examples/direct-to-sd/custom-metrics-sd.yaml
+++ b/custom-metrics-stackdriver-adapter/examples/direct-to-sd/custom-metrics-sd.yaml
@@ -65,7 +65,10 @@ spec:
   metrics:
   - type: Pods
     pods:
-      metricName: foo
-      targetAverageValue: 20
+      metric:
+        name: foo
+      target:
+        type: AverageValue
+        averageValue: 20
 
  


### PR DESCRIPTION
Fixing issue when
```sh
kubectl apply -f custom-metrics-sd.yaml
```
gives the following error:

>error: error validating "examples/direct-to-sd/custom-metrics-sd.yaml": error validating data: [ValidationError(HorizontalPodAutoscaler.spec.metrics[0].pods): unknown field "metricName" in io.k8s.api.autoscaling.v2.PodsMetricSource, ValidationError(HorizontalPodAutoscaler.spec.metrics[0].pods): unknown field "targetAverageValue" in io.k8s.api.autoscaling.v2.PodsMetricSource, ValidationError(HorizontalPodAutoscaler.spec.metrics[0].pods): missing required field "metric" in io.k8s.api.autoscaling.v2.PodsMetricSource, ValidationError(HorizontalPodAutoscaler.spec.metrics[0].pods): missing required field "target" in io.k8s.api.autoscaling.v2.PodsMetricSource]; if you choose to ignore these errors, turn validation off with --validate=false
