### PR TITLE
Removed namespace from metrics reader clusterRole

### DIFF
--- a/custom-metrics-stackdriver-adapter/deploy/production/adapter_new_resource_model.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/production/adapter_new_resource_model.yaml
@@ -40,7 +40,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: custom-metrics-resource-reader
-  namespace: custom-metrics
 rules:
 - apiGroups:
   - ""

--- a/custom-metrics-stackdriver-adapter/deploy/staging/adapter_new_resource_model.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/staging/adapter_new_resource_model.yaml
@@ -44,7 +44,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: custom-metrics-resource-reader
-  namespace: custom-metrics
 rules:
 - apiGroups:
   - ""

--- a/custom-metrics-stackdriver-adapter/deploy/test/adapter_new_resource_model_with_core_metrics.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/test/adapter_new_resource_model_with_core_metrics.yaml
@@ -44,7 +44,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: custom-metrics-resource-reader
-  namespace: custom-metrics
 rules:
 - apiGroups:
   - ""


### PR DESCRIPTION
Custom metrics adapter deployment has ClusterRole `custom-metrics-resource-reader` with namespace meta.
This causes deployments to fail.