### PR TITLE
remove deprecated govendor license generation

### DIFF
--- a/prometheus-to-sd/Dockerfile
+++ b/prometheus-to-sd/Dockerfile
@@ -20,12 +20,7 @@ ARG TARGETARCH
 ARG TARGETOS
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -mod=vendor -o /monitor
 
-RUN apk update \
-    && apk add --no-cache govendor \
-    && govendor license +vendor > /NOTICES
-
 FROM --platform=$TARGETPLATFORM gcr.io/distroless/static:latest
 # nobody:nobody
 USER 65534:65534
 COPY --from=builder /monitor /
-COPY --from=builder /NOTICES /


### PR DESCRIPTION
govendor is no longer usable in our builds and has been replaced by go.mod for a while now.
Instead we'll rely on our internal license scanner for injecting notices and sources.