### PR TITLE
Install Dependabot to support Docker and go module updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: docker
+  directory: /
+  schedule:
+    interval: daily
+- package-ecosystem: gomod
+  directory: /
+  schedule:
+    interval: daily


### PR DESCRIPTION
Enable Dependabot for `Dockerfile` and `go.mod` dependency updates. 
This should hopefully help keep our go module and base / builder images up to date.

The PR was generated by a script, I used this as an opportunity to do a sanity check. Let me know if I should change any of the configuration values.