### PR TITLE
Change Dependabot update frequency from daily to weekly

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,8 +3,8 @@ updates:
 - package-ecosystem: docker
   directory: /
   schedule:
-    interval: daily
+    interval: weekly
 - package-ecosystem: gomod
   directory: /
   schedule:
-    interval: daily
+    interval: weekly


### PR DESCRIPTION
This just changes the update interval from `daily` to `weekly` in an effort to create fewer PRs for updates.