### PR TITLE
Update dependabot config to explicitly list directories

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,3 +8,39 @@ updates:
   directory: /
   schedule:
     interval: weekly
+- package-ecosystem: docker
+  directory: /prometheus-to-sd
+  schedule:
+    interval: weekly
+- package-ecosystem: docker
+  directory: /kubelet-to-gcm
+  schedule:
+    interval: weekly
+- package-ecosystem: docker
+  directory: /fluentd-gcp-scaler
+  schedule:
+    interval: weekly
+- package-ecosystem: docker
+  directory: /event-exporter
+  schedule:
+    interval: weekly
+- package-ecosystem: docker
+  directory: /custom-metrics-stackdriver-adapter
+  schedule:
+    interval: weekly
+- package-ecosystem: gomod
+  directory: /prometheus-to-sd
+  schedule:
+    interval: weekly
+- package-ecosystem: gomod
+  directory: /kubelet-to-gcm
+  schedule:
+    interval: weekly
+- package-ecosystem: gomod
+  directory: /event-exporter
+  schedule:
+    interval: weekly
+- package-ecosystem: gomod
+  directory: /custom-metrics-stackdriver-adapter
+  schedule:
+    interval: weekly

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,14 +1,6 @@
 version: 2
 updates:
 - package-ecosystem: docker
-  directory: /
-  schedule:
-    interval: weekly
-- package-ecosystem: gomod
-  directory: /
-  schedule:
-    interval: weekly
-- package-ecosystem: docker
   directory: /prometheus-to-sd
   schedule:
     interval: weekly


### PR DESCRIPTION
This should make ensure dependabot operates on each, and ignore the "archived" directory.