### PR TITLE
Fix OOM and "http2: stream closed" issue by only returning one item in ListAllMetrics by default

### DIFF
--- a/custom-metrics-stackdriver-adapter/Makefile
+++ b/custom-metrics-stackdriver-adapter/Makefile
@@ -3,7 +3,7 @@ GOOS?=linux
 OUT_DIR?=build
 PACKAGE=github.com/GoogleCloudPlatform/k8s-stackdriver/custom-metrics-stackdriver-adapter
 PREFIX?=staging-k8s.gcr.io
-TAG = v0.13.1
+TAG = v0.14.0
 PKG := $(shell find pkg/* -type f)
 
 .PHONY: build docker push test clean


### PR DESCRIPTION
Adapted from https://github.com/GoogleCloudPlatform/k8s-stackdriver/pull/311

Also,
1. Instead of returning empty, this PR returns 1 metric resource item. Because returning empty response is not fine for generic clients that list resources with api discovery, like the namespace garbage collector and GitOps serivces like Config Sync and ArgoCD. An APIService that returns an empty list is invalid and causes an error in client-go.

1. added a feature-gate `list-full-custom-metrics` with default value = false.

1. metricsCache is the same as before previous.


Fixes: https://github.com/GoogleCloudPlatform/k8s-stackdriver/issues/582, https://github.com/GoogleCloudPlatform/k8s-stackdriver/issues/545, https://github.com/GoogleCloudPlatform/k8s-stackdriver/issues/510, https://github.com/GoogleCloudPlatform/k8s-stackdriver/issues/458

### Tested: 

```
# HPA target deployment has 5 pods 
# now
NAME                                                 CPU(cores)   MEMORY(bytes)
custom-metrics-stackdriver-adapter-b8844b4d9-86b9h   5m           19Mi

# before
NAME                                                  CPU(cores)   MEMORY(bytes)
custom-metrics-stackdriver-adapter-6878c4fc56-r8pnt   5m           45Mi
```

The memory drop will be more significant in a large cluster.


"http2: stream closed" is from calling `/apis/custom.metrics.k8s.io/v1beta2`.  Since it only returns 1 item, it's hard to have timeout error.

### ListMetrics is not used in HPA, so it's safe to change it.
![Screenshot 2024-01-10 at 9 22 31 AM](https://github.com/GoogleCloudPlatform/k8s-stackdriver/assets/78218824/2b7c237b-4ced-45cb-ae86-1a0d97c7d613)


### Cons: 
API discovery around /apis/[custom.metrics.k8s.io/v1beta2](http://custom.metrics.k8s.io/v1beta2) returns an incomplete resource list, instead of listing all available metrics. This is fine since customers can find full metric names from GCP monitoring dashboards.The feature-gate `list-full-custom-metrics` returns all custom-metrics when it's true.

```bash
kubectl get --raw "/apis/custom.metrics.k8s.io/v1beta2"

{"kind":"APIResourceList","apiVersion":"v1","groupVersion":"custom.metrics.k8s.io/v1beta2","resources":[{"name":"*/actions.googleapis.com|smarthome_action|camerastream|request_count","singularName":"","namespaced":true,"kind":"MetricValueList","verbs":["get"]}]}
```