### PR TITLE
Update custom-metrics-stackdriver-adapter version to v0.14.2-gke.0

### DIFF
--- a/custom-metrics-stackdriver-adapter/deploy/production/adapter.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/production/adapter.yaml
@@ -72,7 +72,7 @@ spec:
     spec:
       serviceAccountName: custom-metrics-stackdriver-adapter
       containers:
-      - image: gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.13.1-gke.0
+      - image: gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.14.2-gke.0
         imagePullPolicy: Always
         name: pod-custom-metrics-stackdriver-adapter
         command:

--- a/custom-metrics-stackdriver-adapter/deploy/production/adapter_new_resource_model.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/production/adapter_new_resource_model.yaml
@@ -89,7 +89,7 @@ spec:
     spec:
       serviceAccountName: custom-metrics-stackdriver-adapter
       containers:
-      - image: gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.13.1-gke.0
+      - image: gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.14.2-gke.0
         imagePullPolicy: Always
         name: pod-custom-metrics-stackdriver-adapter
         command:
@@ -99,10 +99,10 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 400Mi
+            memory: 200Mi
           requests:
             cpu: 250m
-            memory: 400Mi
+            memory: 200Mi
 ---
 apiVersion: v1
 kind: Service

--- a/custom-metrics-stackdriver-adapter/deploy/staging/adapter_new_resource_model.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/staging/adapter_new_resource_model.yaml
@@ -93,7 +93,7 @@ spec:
     spec:
       serviceAccountName: custom-metrics-stackdriver-adapter
       containers:
-      - image: gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.13.1-gke.0
+      - image: gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.14.2-gke.0
         imagePullPolicy: Always
         name: pod-custom-metrics-stackdriver-adapter
         command:

--- a/custom-metrics-stackdriver-adapter/deploy/staging/adapter_old_resource_model.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/staging/adapter_old_resource_model.yaml
@@ -76,7 +76,7 @@ spec:
     spec:
       serviceAccountName: custom-metrics-stackdriver-adapter
       containers:
-      - image: gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.13.1-gke.0
+      - image: gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.14.2-gke.0
         imagePullPolicy: Always
         name: pod-custom-metrics-stackdriver-adapter
         command:

--- a/custom-metrics-stackdriver-adapter/deploy/test/adapter_new_resource_model_with_core_metrics.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/test/adapter_new_resource_model_with_core_metrics.yaml
@@ -93,7 +93,7 @@ spec:
     spec:
       serviceAccountName: custom-metrics-stackdriver-adapter
       containers:
-      - image: gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.13.1-gke.0
+      - image: gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.14.2-gke.0
         imagePullPolicy: Always
         name: pod-custom-metrics-stackdriver-adapter
         command:


### PR DESCRIPTION
At least 2 people have tested this image.

Also revert memory limit to 200Mi (increasing to 400Mi was a short-term mitigation)

![adapter](https://github.com/GoogleCloudPlatform/k8s-stackdriver/assets/78218824/2fba5d9a-ae1c-45e6-90c5-57ec83a6997e)

Fixes: #545
