### PR TITLE
Add readiness and liveness probe

### DIFF
--- a/custom-metrics-stackdriver-adapter/adapter-beta.yaml
+++ b/custom-metrics-stackdriver-adapter/adapter-beta.yaml
@@ -99,7 +99,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     run: custom-metrics-stackdriver-adapter
     k8s-app: custom-metrics-stackdriver-adapter

--- a/custom-metrics-stackdriver-adapter/deploy/production/adapter.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/production/adapter.yaml
@@ -78,6 +78,23 @@ spec:
         command:
         - /adapter
         - --use-new-resource-model=false
+        - --secure-port=6443
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /readyz
+            port: https
+            scheme: HTTPS
+          initialDelaySeconds: 30
+          periodSeconds: 5
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          initialDelaySeconds: 30
+          periodSeconds: 5
         resources:
           limits:
             cpu: 250m

--- a/custom-metrics-stackdriver-adapter/deploy/production/adapter.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/production/adapter.yaml
@@ -120,7 +120,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     run: custom-metrics-stackdriver-adapter
     k8s-app: custom-metrics-stackdriver-adapter

--- a/custom-metrics-stackdriver-adapter/deploy/production/adapter.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/production/adapter.yaml
@@ -79,6 +79,9 @@ spec:
         - /adapter
         - --use-new-resource-model=false
         - --secure-port=6443
+        ports:
+        - containerPort: 6443
+          name: https
         readinessProbe:
           failureThreshold: 5
           httpGet:

--- a/custom-metrics-stackdriver-adapter/deploy/production/adapter_new_resource_model.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/production/adapter_new_resource_model.yaml
@@ -97,6 +97,9 @@ spec:
         - --use-new-resource-model=true
         - --fallback-for-container-metrics=true
         - --secure-port=6443
+        ports:
+        - containerPort: 6443
+          name: https
         readinessProbe:
           failureThreshold: 5
           httpGet:

--- a/custom-metrics-stackdriver-adapter/deploy/production/adapter_new_resource_model.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/production/adapter_new_resource_model.yaml
@@ -89,7 +89,7 @@ spec:
     spec:
       serviceAccountName: custom-metrics-stackdriver-adapter
       containers:
-      - image: gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.14.2-gke.0
+      - image: gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.15.0-gke.0
         imagePullPolicy: Always
         name: pod-custom-metrics-stackdriver-adapter
         command:
@@ -138,7 +138,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     run: custom-metrics-stackdriver-adapter
     k8s-app: custom-metrics-stackdriver-adapter

--- a/custom-metrics-stackdriver-adapter/deploy/production/adapter_new_resource_model.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/production/adapter_new_resource_model.yaml
@@ -96,6 +96,23 @@ spec:
         - /adapter
         - --use-new-resource-model=true
         - --fallback-for-container-metrics=true
+        - --secure-port=6443
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /readyz
+            port: https
+            scheme: HTTPS
+          initialDelaySeconds: 30
+          periodSeconds: 5
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          initialDelaySeconds: 30
+          periodSeconds: 5
         resources:
           limits:
             cpu: 250m

--- a/custom-metrics-stackdriver-adapter/deploy/production/adapter_new_resource_model.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/production/adapter_new_resource_model.yaml
@@ -89,7 +89,7 @@ spec:
     spec:
       serviceAccountName: custom-metrics-stackdriver-adapter
       containers:
-      - image: gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.15.0-gke.0
+      - image: gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.14.2-gke.0
         imagePullPolicy: Always
         name: pod-custom-metrics-stackdriver-adapter
         command:

--- a/custom-metrics-stackdriver-adapter/deploy/staging/adapter_new_resource_model.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/staging/adapter_new_resource_model.yaml
@@ -142,7 +142,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     run: custom-metrics-stackdriver-adapter
     k8s-app: custom-metrics-stackdriver-adapter

--- a/custom-metrics-stackdriver-adapter/deploy/staging/adapter_new_resource_model.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/staging/adapter_new_resource_model.yaml
@@ -100,6 +100,23 @@ spec:
         - /adapter
         - --use-new-resource-model=true
         - --fallback-for-container-metrics=true
+        - --secure-port=6443
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /readyz
+            port: https
+            scheme: HTTPS
+          initialDelaySeconds: 30
+          periodSeconds: 5
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          initialDelaySeconds: 30
+          periodSeconds: 5
         resources:
           limits:
             cpu: 250m

--- a/custom-metrics-stackdriver-adapter/deploy/staging/adapter_new_resource_model.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/staging/adapter_new_resource_model.yaml
@@ -101,6 +101,9 @@ spec:
         - --use-new-resource-model=true
         - --fallback-for-container-metrics=true
         - --secure-port=6443
+        ports:
+        - containerPort: 6443
+          name: https
         readinessProbe:
           failureThreshold: 5
           httpGet:

--- a/custom-metrics-stackdriver-adapter/deploy/staging/adapter_old_resource_model.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/staging/adapter_old_resource_model.yaml
@@ -82,6 +82,23 @@ spec:
         command:
         - /adapter
         - --use-new-resource-model=false
+        - --secure-port=6443
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /readyz
+            port: https
+            scheme: HTTPS
+          initialDelaySeconds: 30
+          periodSeconds: 5
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          initialDelaySeconds: 30
+          periodSeconds: 5
         resources:
           limits:
             cpu: 250m

--- a/custom-metrics-stackdriver-adapter/deploy/staging/adapter_old_resource_model.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/staging/adapter_old_resource_model.yaml
@@ -124,7 +124,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     run: custom-metrics-stackdriver-adapter
     k8s-app: custom-metrics-stackdriver-adapter

--- a/custom-metrics-stackdriver-adapter/deploy/staging/adapter_old_resource_model.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/staging/adapter_old_resource_model.yaml
@@ -83,6 +83,9 @@ spec:
         - /adapter
         - --use-new-resource-model=false
         - --secure-port=6443
+        ports:
+        - containerPort: 6443
+          name: https
         readinessProbe:
           failureThreshold: 5
           httpGet:

--- a/custom-metrics-stackdriver-adapter/deploy/test/adapter_new_resource_model_with_core_metrics.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/test/adapter_new_resource_model_with_core_metrics.yaml
@@ -101,6 +101,9 @@ spec:
         - --use-new-resource-model=true
         - --enable-core-metrics-api
         - --secure-port=6443
+        ports:
+        - containerPort: 6443
+          name: https
         readinessProbe:
           failureThreshold: 5
           httpGet:

--- a/custom-metrics-stackdriver-adapter/deploy/test/adapter_new_resource_model_with_core_metrics.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/test/adapter_new_resource_model_with_core_metrics.yaml
@@ -100,6 +100,23 @@ spec:
         - /adapter
         - --use-new-resource-model=true
         - --enable-core-metrics-api
+        - --secure-port=6443
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /readyz
+            port: https
+            scheme: HTTPS
+          initialDelaySeconds: 30
+          periodSeconds: 5
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          initialDelaySeconds: 30
+          periodSeconds: 5
         resources:
           limits:
             cpu: 250m

--- a/custom-metrics-stackdriver-adapter/deploy/test/adapter_new_resource_model_with_core_metrics.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/test/adapter_new_resource_model_with_core_metrics.yaml
@@ -142,7 +142,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     run: custom-metrics-stackdriver-adapter
     k8s-app: custom-metrics-stackdriver-adapter

--- a/custom-metrics-stackdriver-adapter/pkg/adapter/coreprovider/coreprovider_test.go
+++ b/custom-metrics-stackdriver-adapter/pkg/adapter/coreprovider/coreprovider_test.go
@@ -759,7 +759,7 @@ func TestCoreprovider_GetPodMetrics_Many(t *testing.T) {
 		t.Fatalf("Unexpected result. Expected len: \n%v,\n received: \n%v", len(expectedPodMetrics), len(podMetrics))
 	}
 
-	if diff := cmp.Diff(expectedPodMetrics, podMetrics, cmpopts.SortMaps(func(a, b metrics.ContainerMetrics) bool { return a.Name < b.Name }), cmpopts.IgnoreFields(metrics.PodMetrics{}, "ObjectMeta", "CreationTimestamp")); diff != "" {
+	if diff := cmp.Diff(expectedPodMetrics, podMetrics, cmpopts.SortSlices(func(a, b metrics.ContainerMetrics) bool { return a.Name < b.Name }), cmpopts.IgnoreFields(metrics.PodMetrics{}, "ObjectMeta", "CreationTimestamp")); diff != "" {
 		t.Errorf("Has a diff, (-want, +got): %s. Want: %v, got: %v.", diff, expectedPodMetrics, podMetrics)
 	}
 


### PR DESCRIPTION
Fixes: [#485](https://github.com/GoogleCloudPlatform/k8s-stackdriver/issues/485)


Tested: 
```
curl -k https://localhost:6443/livez
ok

curl -k https://localhost:6443/readyz
ok

k top pods -n custom-metrics
NAME                                                 CPU(cores)   MEMORY(bytes)   
custom-metrics-stackdriver-adapter-cddcdcf54-vdhlj   3m           32Mi 
```