### PR TITLE
Revert "Add readiness and liveness probe"

### DIFF
--- a/custom-metrics-stackdriver-adapter/adapter-beta.yaml
+++ b/custom-metrics-stackdriver-adapter/adapter-beta.yaml
@@ -99,7 +99,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 6443
+    targetPort: 443
   selector:
     run: custom-metrics-stackdriver-adapter
     k8s-app: custom-metrics-stackdriver-adapter

--- a/custom-metrics-stackdriver-adapter/deploy/production/adapter.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/production/adapter.yaml
@@ -78,26 +78,6 @@ spec:
         command:
         - /adapter
         - --use-new-resource-model=false
-        - --secure-port=6443
-        ports:
-        - containerPort: 6443
-          name: https
-        readinessProbe:
-          failureThreshold: 5
-          httpGet:
-            path: /readyz
-            port: https
-            scheme: HTTPS
-          initialDelaySeconds: 30
-          periodSeconds: 5
-        livenessProbe:
-          failureThreshold: 5
-          httpGet:
-            path: /livez
-            port: https
-            scheme: HTTPS
-          initialDelaySeconds: 30
-          periodSeconds: 5
         resources:
           limits:
             cpu: 250m
@@ -120,7 +100,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 6443
+    targetPort: 443
   selector:
     run: custom-metrics-stackdriver-adapter
     k8s-app: custom-metrics-stackdriver-adapter

--- a/custom-metrics-stackdriver-adapter/deploy/production/adapter_new_resource_model.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/production/adapter_new_resource_model.yaml
@@ -96,26 +96,6 @@ spec:
         - /adapter
         - --use-new-resource-model=true
         - --fallback-for-container-metrics=true
-        - --secure-port=6443
-        ports:
-        - containerPort: 6443
-          name: https
-        readinessProbe:
-          failureThreshold: 5
-          httpGet:
-            path: /readyz
-            port: https
-            scheme: HTTPS
-          initialDelaySeconds: 30
-          periodSeconds: 5
-        livenessProbe:
-          failureThreshold: 5
-          httpGet:
-            path: /livez
-            port: https
-            scheme: HTTPS
-          initialDelaySeconds: 30
-          periodSeconds: 5
         resources:
           limits:
             cpu: 250m
@@ -138,7 +118,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 6443
+    targetPort: 443
   selector:
     run: custom-metrics-stackdriver-adapter
     k8s-app: custom-metrics-stackdriver-adapter

--- a/custom-metrics-stackdriver-adapter/deploy/staging/adapter_new_resource_model.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/staging/adapter_new_resource_model.yaml
@@ -100,26 +100,6 @@ spec:
         - /adapter
         - --use-new-resource-model=true
         - --fallback-for-container-metrics=true
-        - --secure-port=6443
-        ports:
-        - containerPort: 6443
-          name: https
-        readinessProbe:
-          failureThreshold: 5
-          httpGet:
-            path: /readyz
-            port: https
-            scheme: HTTPS
-          initialDelaySeconds: 30
-          periodSeconds: 5
-        livenessProbe:
-          failureThreshold: 5
-          httpGet:
-            path: /livez
-            port: https
-            scheme: HTTPS
-          initialDelaySeconds: 30
-          periodSeconds: 5
         resources:
           limits:
             cpu: 250m
@@ -142,7 +122,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 6443
+    targetPort: 443
   selector:
     run: custom-metrics-stackdriver-adapter
     k8s-app: custom-metrics-stackdriver-adapter

--- a/custom-metrics-stackdriver-adapter/deploy/staging/adapter_old_resource_model.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/staging/adapter_old_resource_model.yaml
@@ -82,26 +82,6 @@ spec:
         command:
         - /adapter
         - --use-new-resource-model=false
-        - --secure-port=6443
-        ports:
-        - containerPort: 6443
-          name: https
-        readinessProbe:
-          failureThreshold: 5
-          httpGet:
-            path: /readyz
-            port: https
-            scheme: HTTPS
-          initialDelaySeconds: 30
-          periodSeconds: 5
-        livenessProbe:
-          failureThreshold: 5
-          httpGet:
-            path: /livez
-            port: https
-            scheme: HTTPS
-          initialDelaySeconds: 30
-          periodSeconds: 5
         resources:
           limits:
             cpu: 250m
@@ -124,7 +104,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 6443
+    targetPort: 443
   selector:
     run: custom-metrics-stackdriver-adapter
     k8s-app: custom-metrics-stackdriver-adapter

--- a/custom-metrics-stackdriver-adapter/deploy/test/adapter_new_resource_model_with_core_metrics.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/test/adapter_new_resource_model_with_core_metrics.yaml
@@ -100,26 +100,6 @@ spec:
         - /adapter
         - --use-new-resource-model=true
         - --enable-core-metrics-api
-        - --secure-port=6443
-        ports:
-        - containerPort: 6443
-          name: https
-        readinessProbe:
-          failureThreshold: 5
-          httpGet:
-            path: /readyz
-            port: https
-            scheme: HTTPS
-          initialDelaySeconds: 30
-          periodSeconds: 5
-        livenessProbe:
-          failureThreshold: 5
-          httpGet:
-            path: /livez
-            port: https
-            scheme: HTTPS
-          initialDelaySeconds: 30
-          periodSeconds: 5
         resources:
           limits:
             cpu: 250m
@@ -142,7 +122,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 6443
+    targetPort: 443
   selector:
     run: custom-metrics-stackdriver-adapter
     k8s-app: custom-metrics-stackdriver-adapter

--- a/custom-metrics-stackdriver-adapter/pkg/adapter/coreprovider/coreprovider_test.go
+++ b/custom-metrics-stackdriver-adapter/pkg/adapter/coreprovider/coreprovider_test.go
@@ -759,7 +759,7 @@ func TestCoreprovider_GetPodMetrics_Many(t *testing.T) {
 		t.Fatalf("Unexpected result. Expected len: \n%v,\n received: \n%v", len(expectedPodMetrics), len(podMetrics))
 	}
 
-	if diff := cmp.Diff(expectedPodMetrics, podMetrics, cmpopts.SortSlices(func(a, b metrics.ContainerMetrics) bool { return a.Name < b.Name }), cmpopts.IgnoreFields(metrics.PodMetrics{}, "ObjectMeta", "CreationTimestamp")); diff != "" {
+	if diff := cmp.Diff(expectedPodMetrics, podMetrics, cmpopts.SortMaps(func(a, b metrics.ContainerMetrics) bool { return a.Name < b.Name }), cmpopts.IgnoreFields(metrics.PodMetrics{}, "ObjectMeta", "CreationTimestamp")); diff != "" {
 		t.Errorf("Has a diff, (-want, +got): %s. Want: %v, got: %v.", diff, expectedPodMetrics, podMetrics)
 	}
 

--- a/custom-metrics-stackdriver-adapter/pkg/adapter/coreprovider/coreprovider_test.go
+++ b/custom-metrics-stackdriver-adapter/pkg/adapter/coreprovider/coreprovider_test.go
@@ -759,7 +759,7 @@ func TestCoreprovider_GetPodMetrics_Many(t *testing.T) {
 		t.Fatalf("Unexpected result. Expected len: \n%v,\n received: \n%v", len(expectedPodMetrics), len(podMetrics))
 	}
 
-	if diff := cmp.Diff(expectedPodMetrics, podMetrics, cmpopts.SortMaps(func(a, b metrics.ContainerMetrics) bool { return a.Name < b.Name }), cmpopts.IgnoreFields(metrics.PodMetrics{}, "ObjectMeta", "CreationTimestamp")); diff != "" {
+        if diff := cmp.Diff(expectedPodMetrics, podMetrics, cmpopts.SortSlices(func(a, b metrics.ContainerMetrics) bool { return a.Name < b.Name }), cmpopts.IgnoreFields(metrics.PodMetrics{}, "ObjectMeta", "CreationTimestamp")); diff != "" {
 		t.Errorf("Has a diff, (-want, +got): %s. Want: %v, got: %v.", diff, expectedPodMetrics, podMetrics)
 	}
 

--- a/custom-metrics-stackdriver-adapter/pkg/adapter/coreprovider/coreprovider_test.go
+++ b/custom-metrics-stackdriver-adapter/pkg/adapter/coreprovider/coreprovider_test.go
@@ -759,7 +759,7 @@ func TestCoreprovider_GetPodMetrics_Many(t *testing.T) {
 		t.Fatalf("Unexpected result. Expected len: \n%v,\n received: \n%v", len(expectedPodMetrics), len(podMetrics))
 	}
 
-        if diff := cmp.Diff(expectedPodMetrics, podMetrics, cmpopts.SortSlices(func(a, b metrics.ContainerMetrics) bool { return a.Name < b.Name }), cmpopts.IgnoreFields(metrics.PodMetrics{}, "ObjectMeta", "CreationTimestamp")); diff != "" {
+	if diff := cmp.Diff(expectedPodMetrics, podMetrics, cmpopts.SortSlices(func(a, b metrics.ContainerMetrics) bool { return a.Name < b.Name }), cmpopts.IgnoreFields(metrics.PodMetrics{}, "ObjectMeta", "CreationTimestamp")); diff != "" {
 		t.Errorf("Has a diff, (-want, +got): %s. Want: %v, got: %v.", diff, expectedPodMetrics, podMetrics)
 	}
 


### PR DESCRIPTION
Reverts GoogleCloudPlatform/k8s-stackdriver#710
Fixes https://github.com/GoogleCloudPlatform/k8s-stackdriver/issues/721
Changing port number might bring downtime.