### PR TITLE
Added command line arguments for GCP settings

### DIFF
--- a/custom-metrics-stackdriver-adapter/Dockerfile
+++ b/custom-metrics-stackdriver-adapter/Dockerfile
@@ -15,7 +15,7 @@
 FROM golang:1.22-alpine as builder
 WORKDIR ${GOPATH}/src/github.com/GoogleCloudPlatform/k8s-stackdriver/custom-metrics-stackdriver-adapter
 COPY . ./
-RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -o /adapter
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=readonly -o /adapter
 RUN ! ldd cluster-addons-bootstrap # Assert that the compiled bin is statically linked
 
 FROM gcr.io/distroless/static


### PR DESCRIPTION
Allows passing command line parameters from helm as follows:

  command:
  - /adapter
  - --project-id={{ .Values.projectId }}
  - --location={{ .Values.location }}
  - --cluster={{ .Values.cluster }}