### PR TITLE
Revert "Revert "Upgrade metrics adapter to v0.15.0-gke.0""

### DIFF
--- a/custom-metrics-stackdriver-adapter/deploy/production/adapter.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/production/adapter.yaml
@@ -72,7 +72,7 @@ spec:
     spec:
       serviceAccountName: custom-metrics-stackdriver-adapter
       containers:
-      - image: gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.14.2-gke.0
+      - image: gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.15.0-gke.0
         imagePullPolicy: Always
         name: pod-custom-metrics-stackdriver-adapter
         command:

--- a/custom-metrics-stackdriver-adapter/deploy/production/adapter_new_resource_model.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/production/adapter_new_resource_model.yaml
@@ -89,7 +89,7 @@ spec:
     spec:
       serviceAccountName: custom-metrics-stackdriver-adapter
       containers:
-      - image: gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.14.2-gke.0
+      - image: gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.15.0-gke.0
         imagePullPolicy: Always
         name: pod-custom-metrics-stackdriver-adapter
         command:

--- a/custom-metrics-stackdriver-adapter/deploy/staging/adapter_new_resource_model.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/staging/adapter_new_resource_model.yaml
@@ -93,7 +93,7 @@ spec:
     spec:
       serviceAccountName: custom-metrics-stackdriver-adapter
       containers:
-      - image: gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.14.2-gke.0
+      - image: gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.15.0-gke.0
         imagePullPolicy: Always
         name: pod-custom-metrics-stackdriver-adapter
         command:

--- a/custom-metrics-stackdriver-adapter/deploy/staging/adapter_old_resource_model.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/staging/adapter_old_resource_model.yaml
@@ -76,7 +76,7 @@ spec:
     spec:
       serviceAccountName: custom-metrics-stackdriver-adapter
       containers:
-      - image: gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.14.2-gke.0
+      - image: gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.15.0-gke.0
         imagePullPolicy: Always
         name: pod-custom-metrics-stackdriver-adapter
         command:

--- a/custom-metrics-stackdriver-adapter/deploy/test/adapter_new_resource_model_with_core_metrics.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/test/adapter_new_resource_model_with_core_metrics.yaml
@@ -93,7 +93,7 @@ spec:
     spec:
       serviceAccountName: custom-metrics-stackdriver-adapter
       containers:
-      - image: gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.14.2-gke.0
+      - image: gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.15.0-gke.0
         imagePullPolicy: Always
         name: pod-custom-metrics-stackdriver-adapter
         command:


### PR DESCRIPTION
Reverts GoogleCloudPlatform/k8s-stackdriver#735

#729

Now, we are 100% sure it's not related to our version bump around client-go. Because one user confirmed that same issue happened with this older version.