### PR TITLE
Add a fake metric to the external metrics listing api

### DIFF
--- a/custom-metrics-stackdriver-adapter/pkg/adapter/provider/provider.go
+++ b/custom-metrics-stackdriver-adapter/pkg/adapter/provider/provider.go
@@ -352,9 +352,13 @@ func (p *StackdriverProvider) GetExternalMetric(ctx context.Context, namespace s
 }
 
 // ListAllExternalMetrics returns a list of available external metrics.
-// Not implemented (currently returns empty list).
+// Not implemented (currently returns a list of one fake metric).
 func (p *StackdriverProvider) ListAllExternalMetrics() []provider.ExternalMetricInfo {
-	return []provider.ExternalMetricInfo{}
+	return []provider.ExternalMetricInfo{
+		{
+			Metric: "externalmetrics",
+		},
+	}
 }
 
 func min(a, b int) int {


### PR DESCRIPTION
`Helm install` will fail with empty metrics list, this PR should fix the issue. 