### PR TITLE
Revert "Bump golang from 1.22.2 to 1.22.5 in /prometheus-to-sd"

### DIFF
--- a/prometheus-to-sd/Dockerfile
+++ b/prometheus-to-sd/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM golang:1.22.5 as builder
+FROM --platform=$BUILDPLATFORM golang:1.22.2 as builder
 WORKDIR ${GOPATH}/src/github.com/GoogleCloudPlatform/k8s-stackdriver/prometheus-to-sd
 COPY . ./
 


### PR DESCRIPTION
Reverts GoogleCloudPlatform/k8s-stackdriver#738 to fix presubmit failures