### PR TITLE
fix(adapter): initialize klog into flags, to allow setting klog settings

### DIFF
--- a/custom-metrics-stackdriver-adapter/Makefile
+++ b/custom-metrics-stackdriver-adapter/Makefile
@@ -3,7 +3,7 @@ GOOS?=linux
 OUT_DIR?=build
 PACKAGE=github.com/GoogleCloudPlatform/k8s-stackdriver/custom-metrics-stackdriver-adapter
 PREFIX?=staging-k8s.gcr.io
-TAG = v0.15.1
+TAG = v0.15.2
 PKG := $(shell find pkg/* -type f)
 
 .PHONY: build docker push test clean

--- a/custom-metrics-stackdriver-adapter/adapter.go
+++ b/custom-metrics-stackdriver-adapter/adapter.go
@@ -181,6 +181,7 @@ func main() {
 
 	flags := cmd.Flags()
 
+	klog.InitFlags(nil)                  // init klog flags into global flagset
 	flags.AddGoFlagSet(flag.CommandLine) // make sure we get the klog flags
 
 	serverOptions := stackdriverAdapterServerOptions{


### PR DESCRIPTION
Fixes update to klog v2 in f3a96b5ed2c4dd345390001cee3500f4cca3c41c, which requires klog.InitFlags(nil) to be called before.

Fixes #640 when used with `-v=1`.