### PR TITLE
Fix the fallback for container metrics logic to query both container and pod metrics

### DIFF
--- a/custom-metrics-stackdriver-adapter/pkg/adapter/coreprovider/client.go
+++ b/custom-metrics-stackdriver-adapter/pkg/adapter/coreprovider/client.go
@@ -53,7 +53,7 @@ func (p *stackdriverCoreClient) getPodMetric(podsNames []string, metricName, met
 		segmentEnd := min((i+1)*translator.MaxNumOfArgsInOneOfFilter, len(podsNames))
 
 		stackdriverRequest, err := translator.NewQueryBuilder(p.translator, metricName).
-			AsContainerType().
+			EnforceContainerType().
 			WithPodNames(podsNames[segmentBeg:segmentEnd]).
 			WithMetricKind(metricKind).
 			WithMetricValueType(metricValueType).

--- a/custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder.go
+++ b/custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder.go
@@ -40,7 +40,7 @@ var (
 	allowedExternalMetricsLabelPrefixes  = []string{"metric.labels", "resource.labels", "metadata.system_labels", "metadata.user_labels"}
 	allowedExternalMetricsFullLabelNames = []string{"resource.type", "reducer"}
 	// allowedCustomMetricsLabelPrefixes and allowedCustomMetricsFullLabelNames specify all metric labels allowed for querying
-	allowedCustomMetricsLabelPrefixes  = []string{"metric.labels"}
+	allowedCustomMetricsLabelPrefixes  = []string{"metric.labels", "resource.labels"}
 	allowedCustomMetricsFullLabelNames = []string{"reducer"}
 	allowedReducers                    = map[string]bool{
 		"REDUCE_NONE":          true,

--- a/custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder.go
+++ b/custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder.go
@@ -169,15 +169,16 @@ func (nc nodeValues) getNodeNames() []string {
 //
 // use NewQueryBuilder() to initialize
 type QueryBuilder struct {
-	translator           *Translator     // translator provides configurations to filter
-	metricName           string          // metricName is the metric name to filter
-	metricKind           string          // metricKind is the metric kind to filter
-	metricValueType      string          // metricValueType is the metric value type to filter
-	metricSelector       labels.Selector // metricSelector is the metric selector to filtere
-	namespace            string          // namespace is the namespace to filter (mutually exclusive with nodes)
-	pods                 podValues       // pods is the pods to filter (mutually exclusive with nodes)
-	nodes                nodeValues      // nodes is the nodes to filter (mutually exclusive with namespace, pods)
-	enforceContainerType bool            // enforceContainerType decides whether to enforce using container type filter schema
+	translator              *Translator     // translator provides configurations to filter
+	metricName              string          // metricName is the metric name to filter
+	metricKind              string          // metricKind is the metric kind to filter
+	metricValueType         string          // metricValueType is the metric value type to filter
+	metricSelector          labels.Selector // metricSelector is the metric selector to filtere
+	namespace               string          // namespace is the namespace to filter (mutually exclusive with nodes)
+	pods                    podValues       // pods is the pods to filter (mutually exclusive with nodes)
+	nodes                   nodeValues      // nodes is the nodes to filter (mutually exclusive with namespace, pods)
+	enforceContainerType    bool            // enforceContainerType decides whether to enforce using container type filter schema
+	enforcePodContainerType bool            // enforcePodContainerType decides wether to to enforce using pod_container type filter schema
 }
 
 // NewQueryBuilder is the initiator for QueryBuilder
@@ -314,11 +315,19 @@ func (qb QueryBuilder) getResourceNames() []string {
 	return qb.pods.getPodIDs()
 }
 
-// AsContainerType enforces to query k8s_container type metrics
+// EnforceContainerType enforces to query k8s_container type metrics
 //
 // it it valid only when useNewResourceModel is true
-func (qb QueryBuilder) AsContainerType() QueryBuilder {
+func (qb QueryBuilder) EnforceContainerType() QueryBuilder {
 	qb.enforceContainerType = true
+	return qb
+}
+
+// EnforcePodContainerType enforces to query both k8s_pod and k8s_container type metrics
+//
+// it it valid only when useNewResourceModel is true
+func (qb QueryBuilder) EnforcePodContainerType() QueryBuilder {
+	qb.enforcePodContainerType = true
 	return qb
 }
 
@@ -366,7 +375,7 @@ func (qb QueryBuilder) validate() error {
 		return apierr.NewBadRequest("distributions are not supported")
 	}
 
-	if qb.enforceContainerType && !qb.translator.useNewResourceModel {
+	if !qb.translator.useNewResourceModel && (qb.enforceContainerType || qb.enforcePodContainerType) {
 		return apierr.NewInternalError(fmt.Errorf("illegal state! Container metrics works only with new resource model"))
 	}
 
@@ -390,6 +399,11 @@ func (qb QueryBuilder) getFilterBuilder() utils.FilterBuilder {
 	// container type FilterBuilder
 	if qb.enforceContainerType {
 		return utils.NewFilterBuilder(utils.SchemaTypes[utils.ContainerSchemaKey])
+	}
+
+	// pod_container type FilterBuilder
+	if qb.enforcePodContainerType {
+		return utils.NewFilterBuilder(utils.SchemaTypes[utils.PodContainerSchemaKey])
 	}
 
 	// prometheus type FilterBuilder

--- a/custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go
+++ b/custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go
@@ -422,35 +422,53 @@ func TestTranslator_QueryBuilder_Container_Single(t *testing.T) {
 		},
 	}
 	metricName := "my/custom/metric"
-	request, err := NewQueryBuilder(translator, metricName).
-		AsContainerType().
-		WithPods(&v1.PodList{Items: []v1.Pod{pod}}).
-		WithMetricKind("GAUGE").
-		WithMetricValueType("INT64").
-		WithMetricSelector(labels.Everything()).
-		WithNamespace("default").
-		Build()
-	if err != nil {
-		t.Errorf("Translation error: %s", err)
-	}
-	filters := []string{
-		"metric.type = \"my/custom/metric\"",
-		"resource.labels.project_id = \"my-project\"",
-		"resource.labels.cluster_name = \"my-cluster\"",
-		"resource.labels.location = \"my-zone\"",
-		"resource.labels.namespace_name = \"default\"",
-		"resource.labels.pod_name = \"my-pod-name\"",
-		"resource.type = \"k8s_container\"",
-	}
-	sort.Strings(filters)
-	expectedRequest := sdService.Projects.TimeSeries.List("projects/my-project").
-		Filter(strings.Join(filters, " AND ")).
-		IntervalStartTime("2017-01-02T13:00:00Z").
-		IntervalEndTime("2017-01-02T13:02:00Z").
-		AggregationPerSeriesAligner("ALIGN_NEXT_OLDER").
-		AggregationAlignmentPeriod("120s")
-	if !reflect.DeepEqual(*request, *expectedRequest) {
-		t.Errorf("Unexpected result. Expected: \n%v,\n received: \n%v", expectedRequest, request)
+	for _, tc := range map[string]struct {
+		podType            bool
+		resourceTypeFilter string
+	}{
+		"container type": {
+			podType:            false,
+			resourceTypeFilter: "resource.type = \"k8s_container\"",
+		},
+		"pod_container type": {
+			podType:            true,
+			resourceTypeFilter: "resource.type = one_of(k8s_pod,k8s_container)",
+		},
+	} {
+		queryBuilder := NewQueryBuilder(translator, metricName).
+			WithPods(&v1.PodList{Items: []v1.Pod{pod}}).
+			WithMetricKind("GAUGE").
+			WithMetricValueType("INT64").
+			WithMetricSelector(labels.Everything()).
+			WithNamespace("default")
+		if tc.podType {
+			queryBuilder = queryBuilder.EnforcePodContainerType()
+		} else {
+			queryBuilder = queryBuilder.EnforceContainerType()
+		}
+		request, err := queryBuilder.Build()
+		if err != nil {
+			t.Errorf("Translation error: %s", err)
+		}
+		filters := []string{
+			"metric.type = \"my/custom/metric\"",
+			"resource.labels.project_id = \"my-project\"",
+			"resource.labels.cluster_name = \"my-cluster\"",
+			"resource.labels.location = \"my-zone\"",
+			"resource.labels.namespace_name = \"default\"",
+			"resource.labels.pod_name = \"my-pod-name\"",
+			tc.resourceTypeFilter,
+		}
+		sort.Strings(filters)
+		expectedRequest := sdService.Projects.TimeSeries.List("projects/my-project").
+			Filter(strings.Join(filters, " AND ")).
+			IntervalStartTime("2017-01-02T13:00:00Z").
+			IntervalEndTime("2017-01-02T13:02:00Z").
+			AggregationPerSeriesAligner("ALIGN_NEXT_OLDER").
+			AggregationAlignmentPeriod("120s")
+		if !reflect.DeepEqual(*request, *expectedRequest) {
+			t.Errorf("Unexpected result. Expected: \n%v,\n received: \n%v", expectedRequest, request)
+		}
 	}
 }
 
@@ -464,34 +482,52 @@ func TestTranslator_QueryBuilder_Container_SingleWithEmptyNamespace(t *testing.T
 		},
 	}
 	metricName := "my/custom/metric"
-	request, err := NewQueryBuilder(translator, metricName).
-		AsContainerType().
-		WithPods(&v1.PodList{Items: []v1.Pod{pod}}).
-		WithMetricKind("GAUGE").
-		WithMetricValueType("INT64").
-		WithMetricSelector(labels.Everything()).
-		WithNamespace(AllNamespaces).
-		Build()
-	if err != nil {
-		t.Errorf("Translation error: %s", err)
-	}
-	filters := []string{
-		"metric.type = \"my/custom/metric\"",
-		"resource.labels.project_id = \"my-project\"",
-		"resource.labels.cluster_name = \"my-cluster\"",
-		"resource.labels.location = \"my-zone\"",
-		"resource.labels.pod_name = \"my-pod-name\"",
-		"resource.type = \"k8s_container\"",
-	}
-	sort.Strings(filters)
-	expectedRequest := sdService.Projects.TimeSeries.List("projects/my-project").
-		Filter(strings.Join(filters, " AND ")).
-		IntervalStartTime("2017-01-02T13:00:00Z").
-		IntervalEndTime("2017-01-02T13:02:00Z").
-		AggregationPerSeriesAligner("ALIGN_NEXT_OLDER").
-		AggregationAlignmentPeriod("120s")
-	if !reflect.DeepEqual(*request, *expectedRequest) {
-		t.Errorf("Unexpected result. Expected: \n%v,\n received: \n%v", expectedRequest, request)
+	for _, tc := range map[string]struct {
+		podType            bool
+		resourceTypeFilter string
+	}{
+		"container type": {
+			podType:            false,
+			resourceTypeFilter: "resource.type = \"k8s_container\"",
+		},
+		"pod_container type": {
+			podType:            true,
+			resourceTypeFilter: "resource.type = one_of(k8s_pod,k8s_container)",
+		},
+	} {
+		queryBuilder := NewQueryBuilder(translator, metricName).
+			WithPods(&v1.PodList{Items: []v1.Pod{pod}}).
+			WithMetricKind("GAUGE").
+			WithMetricValueType("INT64").
+			WithMetricSelector(labels.Everything()).
+			WithNamespace(AllNamespaces)
+		if tc.podType {
+			queryBuilder = queryBuilder.EnforcePodContainerType()
+		} else {
+			queryBuilder = queryBuilder.EnforceContainerType()
+		}
+		request, err := queryBuilder.Build()
+		if err != nil {
+			t.Errorf("Translation error: %s", err)
+		}
+		filters := []string{
+			"metric.type = \"my/custom/metric\"",
+			"resource.labels.project_id = \"my-project\"",
+			"resource.labels.cluster_name = \"my-cluster\"",
+			"resource.labels.location = \"my-zone\"",
+			"resource.labels.pod_name = \"my-pod-name\"",
+			tc.resourceTypeFilter,
+		}
+		sort.Strings(filters)
+		expectedRequest := sdService.Projects.TimeSeries.List("projects/my-project").
+			Filter(strings.Join(filters, " AND ")).
+			IntervalStartTime("2017-01-02T13:00:00Z").
+			IntervalEndTime("2017-01-02T13:02:00Z").
+			AggregationPerSeriesAligner("ALIGN_NEXT_OLDER").
+			AggregationAlignmentPeriod("120s")
+		if !reflect.DeepEqual(*request, *expectedRequest) {
+			t.Errorf("Unexpected result. Expected: \n%v,\n received: \n%v", expectedRequest, request)
+		}
 	}
 }
 
@@ -505,16 +541,31 @@ func TestTranslator_QueryBuilder_Container_OldResourceModel(t *testing.T) {
 		},
 	}
 	metricName := "my/custom/metric"
-	_, err := NewQueryBuilder(translator, metricName).
-		AsContainerType().
-		WithPods(&v1.PodList{Items: []v1.Pod{pod}}).
-		WithMetricKind("GAUGE").
-		WithMetricValueType("INT64").
-		WithMetricSelector(labels.Everything()).
-		WithNamespace("default").
-		Build()
-	if err == nil {
-		t.Errorf("OldResourceModel should not work with container type query")
+	for _, tc := range map[string]struct {
+		podType bool
+	}{
+		"container type": {
+			podType: false,
+		},
+		"pod_container type": {
+			podType: true,
+		},
+	} {
+		queryBuilder := NewQueryBuilder(translator, metricName).
+			WithPods(&v1.PodList{Items: []v1.Pod{pod}}).
+			WithMetricKind("GAUGE").
+			WithMetricValueType("INT64").
+			WithMetricSelector(labels.Everything()).
+			WithNamespace("default")
+		if tc.podType {
+			queryBuilder = queryBuilder.EnforcePodContainerType()
+		} else {
+			queryBuilder = queryBuilder.EnforceContainerType()
+		}
+		_, err := queryBuilder.Build()
+		if err == nil {
+			t.Errorf("OldResourceModel should not work with container type query")
+		}
 	}
 }
 
@@ -529,36 +580,54 @@ func TestTranslator_QueryBuilder_Container_SingleWithMetricSelector(t *testing.T
 	}
 	metricName := "my/custom/metric"
 	metricSelector, _ := labels.Parse("metric.labels.custom=test")
-	request, err := NewQueryBuilder(translator, metricName).
-		AsContainerType().
-		WithPods(&v1.PodList{Items: []v1.Pod{pod}}).
-		WithMetricKind("GAUGE").
-		WithMetricValueType("INT64").
-		WithMetricSelector(metricSelector).
-		WithNamespace("default").
-		Build()
-	if err != nil {
-		t.Errorf("Translation error: %s", err)
-	}
-	filters := []string{
-		"metric.labels.custom = \"test\"",
-		"metric.type = \"my/custom/metric\"",
-		"resource.labels.project_id = \"my-project\"",
-		"resource.labels.cluster_name = \"my-cluster\"",
-		"resource.labels.location = \"my-zone\"",
-		"resource.labels.namespace_name = \"default\"",
-		"resource.labels.pod_name = \"my-pod-name\"",
-		"resource.type = \"k8s_container\"",
-	}
-	sort.Strings(filters)
-	expectedRequest := sdService.Projects.TimeSeries.List("projects/my-project").
-		Filter(strings.Join(filters, " AND ")).
-		IntervalStartTime("2017-01-02T13:00:00Z").
-		IntervalEndTime("2017-01-02T13:02:00Z").
-		AggregationPerSeriesAligner("ALIGN_NEXT_OLDER").
-		AggregationAlignmentPeriod("120s")
-	if !reflect.DeepEqual(*request, *expectedRequest) {
-		t.Errorf("Unexpected result. Expected: \n%v,\n received: \n%v", expectedRequest, request)
+	for _, tc := range map[string]struct {
+		podType            bool
+		resourceTypeFilter string
+	}{
+		"container type": {
+			podType:            false,
+			resourceTypeFilter: "resource.type = \"k8s_container\"",
+		},
+		"pod_container type": {
+			podType:            true,
+			resourceTypeFilter: "resource.type = one_of(k8s_pod,k8s_container)",
+		},
+	} {
+		queryBuilder := NewQueryBuilder(translator, metricName).
+			WithPods(&v1.PodList{Items: []v1.Pod{pod}}).
+			WithMetricKind("GAUGE").
+			WithMetricValueType("INT64").
+			WithMetricSelector(metricSelector).
+			WithNamespace("default")
+		if tc.podType {
+			queryBuilder = queryBuilder.EnforcePodContainerType()
+		} else {
+			queryBuilder = queryBuilder.EnforceContainerType()
+		}
+		request, err := queryBuilder.Build()
+		if err != nil {
+			t.Errorf("Translation error: %s", err)
+		}
+		filters := []string{
+			"metric.labels.custom = \"test\"",
+			"metric.type = \"my/custom/metric\"",
+			"resource.labels.project_id = \"my-project\"",
+			"resource.labels.cluster_name = \"my-cluster\"",
+			"resource.labels.location = \"my-zone\"",
+			"resource.labels.namespace_name = \"default\"",
+			"resource.labels.pod_name = \"my-pod-name\"",
+			tc.resourceTypeFilter,
+		}
+		sort.Strings(filters)
+		expectedRequest := sdService.Projects.TimeSeries.List("projects/my-project").
+			Filter(strings.Join(filters, " AND ")).
+			IntervalStartTime("2017-01-02T13:00:00Z").
+			IntervalEndTime("2017-01-02T13:02:00Z").
+			AggregationPerSeriesAligner("ALIGN_NEXT_OLDER").
+			AggregationAlignmentPeriod("120s")
+		if !reflect.DeepEqual(*request, *expectedRequest) {
+			t.Errorf("Unexpected result. Expected: \n%v,\n received: \n%v", expectedRequest, request)
+		}
 	}
 }
 
@@ -595,36 +664,55 @@ func TestTranslator_QueryBuilder_Container_Multiple(t *testing.T) {
 		},
 	}
 	metricName := "my/custom/metric"
-	request, err := NewQueryBuilder(translator, metricName).
-		AsContainerType().
-		WithPods(&v1.PodList{Items: []v1.Pod{pod1, pod2}}).
-		WithMetricKind("GAUGE").
-		WithMetricValueType("INT64").
-		WithMetricSelector(labels.Everything()).
-		WithNamespace("default").
-		Build()
-	if err != nil {
-		t.Errorf("Translation error: %s", err)
+	for _, tc := range map[string]struct {
+		podType            bool
+		resourceTypeFilter string
+	}{
+		"container type": {
+			podType:            false,
+			resourceTypeFilter: "resource.type = \"k8s_container\"",
+		},
+		"pod_container type": {
+			podType:            true,
+			resourceTypeFilter: "resource.type = one_of(k8s_pod,k8s_container)",
+		},
+	} {
+		queryBuilder := NewQueryBuilder(translator, metricName).
+			WithPods(&v1.PodList{Items: []v1.Pod{pod1, pod2}}).
+			WithMetricKind("GAUGE").
+			WithMetricValueType("INT64").
+			WithMetricSelector(labels.Everything()).
+			WithNamespace("default")
+		if tc.podType {
+			queryBuilder = queryBuilder.EnforcePodContainerType()
+		} else {
+			queryBuilder = queryBuilder.EnforceContainerType()
+		}
+		request, err := queryBuilder.Build()
+		if err != nil {
+			t.Errorf("Translation error: %s", err)
+		}
+		filters := []string{
+			"metric.type = \"my/custom/metric\"",
+			"resource.labels.project_id = \"my-project\"",
+			"resource.labels.cluster_name = \"my-cluster\"",
+			"resource.labels.location = \"my-zone\"",
+			"resource.labels.namespace_name = \"default\"",
+			"resource.labels.pod_name = one_of(\"my-pod-name-1\",\"my-pod-name-2\")",
+			tc.resourceTypeFilter,
+		}
+		sort.Strings(filters)
+		expectedRequest := sdService.Projects.TimeSeries.List("projects/my-project").
+			Filter(strings.Join(filters, " AND ")).
+			IntervalStartTime("2017-01-02T13:00:00Z").
+			IntervalEndTime("2017-01-02T13:02:00Z").
+			AggregationPerSeriesAligner("ALIGN_NEXT_OLDER").
+			AggregationAlignmentPeriod("120s")
+		if !reflect.DeepEqual(*request, *expectedRequest) {
+			t.Errorf("Unexpected result. Expected: \n%v,\n received: \n%v", *expectedRequest, *request)
+		}
 	}
-	filters := []string{
-		"metric.type = \"my/custom/metric\"",
-		"resource.labels.project_id = \"my-project\"",
-		"resource.labels.cluster_name = \"my-cluster\"",
-		"resource.labels.location = \"my-zone\"",
-		"resource.labels.namespace_name = \"default\"",
-		"resource.labels.pod_name = one_of(\"my-pod-name-1\",\"my-pod-name-2\")",
-		"resource.type = \"k8s_container\"",
-	}
-	sort.Strings(filters)
-	expectedRequest := sdService.Projects.TimeSeries.List("projects/my-project").
-		Filter(strings.Join(filters, " AND ")).
-		IntervalStartTime("2017-01-02T13:00:00Z").
-		IntervalEndTime("2017-01-02T13:02:00Z").
-		AggregationPerSeriesAligner("ALIGN_NEXT_OLDER").
-		AggregationAlignmentPeriod("120s")
-	if !reflect.DeepEqual(*request, *expectedRequest) {
-		t.Errorf("Unexpected result. Expected: \n%v,\n received: \n%v", *expectedRequest, *request)
-	}
+
 }
 
 func TestTranslator_QueryBuilder_Container_MultipleEmptyNamespace(t *testing.T) {
@@ -643,34 +731,52 @@ func TestTranslator_QueryBuilder_Container_MultipleEmptyNamespace(t *testing.T) 
 		},
 	}
 	metricName := "my/custom/metric"
-	request, err := NewQueryBuilder(translator, metricName).
-		AsContainerType().
-		WithPods(&v1.PodList{Items: []v1.Pod{pod1, pod2}}).
-		WithMetricKind("GAUGE").
-		WithMetricValueType("INT64").
-		WithMetricSelector(labels.Everything()).
-		WithNamespace(AllNamespaces).
-		Build()
-	if err != nil {
-		t.Errorf("Translation error: %s", err)
-	}
-	filters := []string{
-		"metric.type = \"my/custom/metric\"",
-		"resource.labels.project_id = \"my-project\"",
-		"resource.labels.cluster_name = \"my-cluster\"",
-		"resource.labels.location = \"my-zone\"",
-		"resource.labels.pod_name = one_of(\"my-pod-name-1\",\"my-pod-name-2\")",
-		"resource.type = \"k8s_container\"",
-	}
-	sort.Strings(filters)
-	expectedRequest := sdService.Projects.TimeSeries.List("projects/my-project").
-		Filter(strings.Join(filters, " AND ")).
-		IntervalStartTime("2017-01-02T13:00:00Z").
-		IntervalEndTime("2017-01-02T13:02:00Z").
-		AggregationPerSeriesAligner("ALIGN_NEXT_OLDER").
-		AggregationAlignmentPeriod("120s")
-	if !reflect.DeepEqual(*request, *expectedRequest) {
-		t.Errorf("Unexpected result. Expected: \n%v,\n received: \n%v", *expectedRequest, *request)
+	for _, tc := range map[string]struct {
+		podType            bool
+		resourceTypeFilter string
+	}{
+		"container type": {
+			podType:            false,
+			resourceTypeFilter: "resource.type = \"k8s_container\"",
+		},
+		"pod_container type": {
+			podType:            true,
+			resourceTypeFilter: "resource.type = one_of(k8s_pod,k8s_container)",
+		},
+	} {
+		queryBuilder := NewQueryBuilder(translator, metricName).
+			WithPods(&v1.PodList{Items: []v1.Pod{pod1, pod2}}).
+			WithMetricKind("GAUGE").
+			WithMetricValueType("INT64").
+			WithMetricSelector(labels.Everything()).
+			WithNamespace(AllNamespaces)
+		if tc.podType {
+			queryBuilder = queryBuilder.EnforcePodContainerType()
+		} else {
+			queryBuilder = queryBuilder.EnforceContainerType()
+		}
+		request, err := queryBuilder.Build()
+		if err != nil {
+			t.Errorf("Translation error: %s", err)
+		}
+		filters := []string{
+			"metric.type = \"my/custom/metric\"",
+			"resource.labels.project_id = \"my-project\"",
+			"resource.labels.cluster_name = \"my-cluster\"",
+			"resource.labels.location = \"my-zone\"",
+			"resource.labels.pod_name = one_of(\"my-pod-name-1\",\"my-pod-name-2\")",
+			tc.resourceTypeFilter,
+		}
+		sort.Strings(filters)
+		expectedRequest := sdService.Projects.TimeSeries.List("projects/my-project").
+			Filter(strings.Join(filters, " AND ")).
+			IntervalStartTime("2017-01-02T13:00:00Z").
+			IntervalEndTime("2017-01-02T13:02:00Z").
+			AggregationPerSeriesAligner("ALIGN_NEXT_OLDER").
+			AggregationAlignmentPeriod("120s")
+		if !reflect.DeepEqual(*request, *expectedRequest) {
+			t.Errorf("Unexpected result. Expected: \n%v,\n received: \n%v", *expectedRequest, *request)
+		}
 	}
 }
 
@@ -691,36 +797,54 @@ func TestTranslator_QueryBuilder_Container_MultipleWithMetricSelctor(t *testing.
 	}
 	metricName := "my/custom/metric"
 	metricSelector, _ := labels.Parse("metric.labels.custom=test")
-	request, err := NewQueryBuilder(translator, metricName).
-		AsContainerType().
-		WithPods(&v1.PodList{Items: []v1.Pod{pod1, pod2}}).
-		WithMetricKind("GAUGE").
-		WithMetricValueType("INT64").
-		WithMetricSelector(metricSelector).
-		WithNamespace("default").
-		Build()
-	if err != nil {
-		t.Errorf("Translation error: %s", err)
-	}
-	filters := []string{
-		"metric.labels.custom = \"test\"",
-		"metric.type = \"my/custom/metric\"",
-		"resource.labels.project_id = \"my-project\"",
-		"resource.labels.cluster_name = \"my-cluster\"",
-		"resource.labels.location = \"my-zone\"",
-		"resource.labels.namespace_name = \"default\"",
-		"resource.labels.pod_name = one_of(\"my-pod-name-1\",\"my-pod-name-2\")",
-		"resource.type = \"k8s_container\"",
-	}
-	sort.Strings(filters)
-	expectedRequest := sdService.Projects.TimeSeries.List("projects/my-project").
-		Filter(strings.Join(filters, " AND ")).
-		IntervalStartTime("2017-01-02T13:00:00Z").
-		IntervalEndTime("2017-01-02T13:02:00Z").
-		AggregationPerSeriesAligner("ALIGN_NEXT_OLDER").
-		AggregationAlignmentPeriod("120s")
-	if !reflect.DeepEqual(*request, *expectedRequest) {
-		t.Errorf("Unexpected result. Expected: \n%v,\n received: \n%v", *expectedRequest, *request)
+	for _, tc := range map[string]struct {
+		podType            bool
+		resourceTypeFilter string
+	}{
+		"container type": {
+			podType:            false,
+			resourceTypeFilter: "resource.type = \"k8s_container\"",
+		},
+		"pod_container type": {
+			podType:            true,
+			resourceTypeFilter: "resource.type = one_of(k8s_pod,k8s_container)",
+		},
+	} {
+		queryBuilder := NewQueryBuilder(translator, metricName).
+			WithPods(&v1.PodList{Items: []v1.Pod{pod1, pod2}}).
+			WithMetricKind("GAUGE").
+			WithMetricValueType("INT64").
+			WithMetricSelector(metricSelector).
+			WithNamespace("default")
+		if tc.podType {
+			queryBuilder = queryBuilder.EnforcePodContainerType()
+		} else {
+			queryBuilder = queryBuilder.EnforceContainerType()
+		}
+		request, err := queryBuilder.Build()
+		if err != nil {
+			t.Errorf("Translation error: %s", err)
+		}
+		filters := []string{
+			"metric.labels.custom = \"test\"",
+			"metric.type = \"my/custom/metric\"",
+			"resource.labels.project_id = \"my-project\"",
+			"resource.labels.cluster_name = \"my-cluster\"",
+			"resource.labels.location = \"my-zone\"",
+			"resource.labels.namespace_name = \"default\"",
+			"resource.labels.pod_name = one_of(\"my-pod-name-1\",\"my-pod-name-2\")",
+			tc.resourceTypeFilter,
+		}
+		sort.Strings(filters)
+		expectedRequest := sdService.Projects.TimeSeries.List("projects/my-project").
+			Filter(strings.Join(filters, " AND ")).
+			IntervalStartTime("2017-01-02T13:00:00Z").
+			IntervalEndTime("2017-01-02T13:02:00Z").
+			AggregationPerSeriesAligner("ALIGN_NEXT_OLDER").
+			AggregationAlignmentPeriod("120s")
+		if !reflect.DeepEqual(*request, *expectedRequest) {
+			t.Errorf("Unexpected result. Expected: \n%v,\n received: \n%v", *expectedRequest, *request)
+		}
 	}
 }
 
@@ -1296,36 +1420,54 @@ func TestTranslator_QueryBuilder_Container_Single_Distribution(t *testing.T) {
 	}
 	metricName := "my/custom/metric"
 	selector, _ := labels.Parse("reducer=REDUCE_PERCENTILE_50")
-	request, err := NewQueryBuilder(translator, metricName).
-		AsContainerType().
-		WithPods(&v1.PodList{Items: []v1.Pod{pod}}).
-		WithMetricKind("DELTA").
-		WithMetricValueType("DISTRIBUTION").
-		WithMetricSelector(selector).
-		WithNamespace("default").
-		Build()
-	if err != nil {
-		t.Errorf("Translation error: %s", err)
-	}
-	filters := []string{
-		"metric.type = \"my/custom/metric\"",
-		"resource.labels.project_id = \"my-project\"",
-		"resource.labels.cluster_name = \"my-cluster\"",
-		"resource.labels.location = \"my-zone\"",
-		"resource.labels.namespace_name = \"default\"",
-		"resource.labels.pod_name = \"my-pod-name\"",
-		"resource.type = \"k8s_container\"",
-	}
-	sort.Strings(filters)
-	expectedRequest := sdService.Projects.TimeSeries.List("projects/my-project").
-		Filter(strings.Join(filters, " AND ")).
-		IntervalStartTime("2017-01-02T13:00:00Z").
-		IntervalEndTime("2017-01-02T13:02:00Z").
-		AggregationPerSeriesAligner("ALIGN_DELTA").
-		AggregationCrossSeriesReducer("REDUCE_PERCENTILE_50").
-		AggregationAlignmentPeriod("60s")
-	if !reflect.DeepEqual(*request, *expectedRequest) {
-		t.Errorf("Unexpected result. Expected: \n%v,\n received: \n%v", expectedRequest, request)
+	for _, tc := range map[string]struct {
+		podType            bool
+		resourceTypeFilter string
+	}{
+		"container type": {
+			podType:            false,
+			resourceTypeFilter: "resource.type = \"k8s_container\"",
+		},
+		"pod_container type": {
+			podType:            true,
+			resourceTypeFilter: "resource.type = one_of(k8s_pod,k8s_container)",
+		},
+	} {
+		queryBuilder := NewQueryBuilder(translator, metricName).
+			WithPods(&v1.PodList{Items: []v1.Pod{pod}}).
+			WithMetricKind("DELTA").
+			WithMetricValueType("DISTRIBUTION").
+			WithMetricSelector(selector).
+			WithNamespace("default")
+		if tc.podType {
+			queryBuilder = queryBuilder.EnforcePodContainerType()
+		} else {
+			queryBuilder = queryBuilder.EnforceContainerType()
+		}
+		request, err := queryBuilder.Build()
+		if err != nil {
+			t.Errorf("Translation error: %s", err)
+		}
+		filters := []string{
+			"metric.type = \"my/custom/metric\"",
+			"resource.labels.project_id = \"my-project\"",
+			"resource.labels.cluster_name = \"my-cluster\"",
+			"resource.labels.location = \"my-zone\"",
+			"resource.labels.namespace_name = \"default\"",
+			"resource.labels.pod_name = \"my-pod-name\"",
+			tc.resourceTypeFilter,
+		}
+		sort.Strings(filters)
+		expectedRequest := sdService.Projects.TimeSeries.List("projects/my-project").
+			Filter(strings.Join(filters, " AND ")).
+			IntervalStartTime("2017-01-02T13:00:00Z").
+			IntervalEndTime("2017-01-02T13:02:00Z").
+			AggregationPerSeriesAligner("ALIGN_DELTA").
+			AggregationCrossSeriesReducer("REDUCE_PERCENTILE_50").
+			AggregationAlignmentPeriod("60s")
+		if !reflect.DeepEqual(*request, *expectedRequest) {
+			t.Errorf("Unexpected result. Expected: \n%v,\n received: \n%v", expectedRequest, request)
+		}
 	}
 }
 
@@ -1340,37 +1482,55 @@ func TestTranslator_GetSDReqForContainer_SingleWithMetricSelector_Distribution(t
 	}
 	metricName := "my/custom/metric"
 	metricSelector, _ := labels.Parse("metric.labels.custom=test,reducer=REDUCE_PERCENTILE_99")
-	request, err := NewQueryBuilder(translator, metricName).
-		AsContainerType().
-		WithPods(&v1.PodList{Items: []v1.Pod{pod}}).
-		WithMetricKind("DELTA").
-		WithMetricValueType("DISTRIBUTION").
-		WithMetricSelector(metricSelector).
-		WithNamespace("default").
-		Build()
-	if err != nil {
-		t.Errorf("Translation error: %s", err)
-	}
-	filters := []string{
-		"metric.labels.custom = \"test\"",
-		"metric.type = \"my/custom/metric\"",
-		"resource.labels.project_id = \"my-project\"",
-		"resource.labels.cluster_name = \"my-cluster\"",
-		"resource.labels.location = \"my-zone\"",
-		"resource.labels.namespace_name = \"default\"",
-		"resource.labels.pod_name = \"my-pod-name\"",
-		"resource.type = \"k8s_container\"",
-	}
-	sort.Strings(filters)
-	expectedRequest := sdService.Projects.TimeSeries.List("projects/my-project").
-		Filter(strings.Join(filters, " AND ")).
-		IntervalStartTime("2017-01-02T13:00:00Z").
-		IntervalEndTime("2017-01-02T13:02:00Z").
-		AggregationPerSeriesAligner("ALIGN_DELTA").
-		AggregationCrossSeriesReducer("REDUCE_PERCENTILE_99").
-		AggregationAlignmentPeriod("60s")
-	if !reflect.DeepEqual(*request, *expectedRequest) {
-		t.Errorf("Unexpected result. Expected: \n%v,\n received: \n%v", expectedRequest, request)
+	for _, tc := range map[string]struct {
+		podType            bool
+		resourceTypeFilter string
+	}{
+		"container type": {
+			podType:            false,
+			resourceTypeFilter: "resource.type = \"k8s_container\"",
+		},
+		"pod_container type": {
+			podType:            true,
+			resourceTypeFilter: "resource.type = one_of(k8s_pod,k8s_container)",
+		},
+	} {
+		queryBuilder := NewQueryBuilder(translator, metricName).
+			WithPods(&v1.PodList{Items: []v1.Pod{pod}}).
+			WithMetricKind("DELTA").
+			WithMetricValueType("DISTRIBUTION").
+			WithMetricSelector(metricSelector).
+			WithNamespace("default")
+		if tc.podType {
+			queryBuilder = queryBuilder.EnforcePodContainerType()
+		} else {
+			queryBuilder = queryBuilder.EnforceContainerType()
+		}
+		request, err := queryBuilder.Build()
+		if err != nil {
+			t.Errorf("Translation error: %s", err)
+		}
+		filters := []string{
+			"metric.labels.custom = \"test\"",
+			"metric.type = \"my/custom/metric\"",
+			"resource.labels.project_id = \"my-project\"",
+			"resource.labels.cluster_name = \"my-cluster\"",
+			"resource.labels.location = \"my-zone\"",
+			"resource.labels.namespace_name = \"default\"",
+			"resource.labels.pod_name = \"my-pod-name\"",
+			tc.resourceTypeFilter,
+		}
+		sort.Strings(filters)
+		expectedRequest := sdService.Projects.TimeSeries.List("projects/my-project").
+			Filter(strings.Join(filters, " AND ")).
+			IntervalStartTime("2017-01-02T13:00:00Z").
+			IntervalEndTime("2017-01-02T13:02:00Z").
+			AggregationPerSeriesAligner("ALIGN_DELTA").
+			AggregationCrossSeriesReducer("REDUCE_PERCENTILE_99").
+			AggregationAlignmentPeriod("60s")
+		if !reflect.DeepEqual(*request, *expectedRequest) {
+			t.Errorf("Unexpected result. Expected: \n%v,\n received: \n%v", expectedRequest, request)
+		}
 	}
 }
 

--- a/custom-metrics-stackdriver-adapter/pkg/adapter/translator/utils/filter_builder.go
+++ b/custom-metrics-stackdriver-adapter/pkg/adapter/translator/utils/filter_builder.go
@@ -115,6 +115,8 @@ func NewFilterBuilder(resourceType string) FilterBuilder {
 		schema = PodSchema
 	case PodContainerType:
 		schema = PodContainerSchema
+	case ContainerType:
+		schema = ContainerSchema
 	case PrometheusType:
 		schema = PrometheusSchema
 	case NodeType:

--- a/custom-metrics-stackdriver-adapter/pkg/adapter/translator/utils/filter_builder.go
+++ b/custom-metrics-stackdriver-adapter/pkg/adapter/translator/utils/filter_builder.go
@@ -21,16 +21,18 @@ type Schema struct {
 }
 
 const (
-	PodSchemaKey        = "pod"               // PodSchemaKey is the key to use pod type filter schema.
-	ContainerSchemaKey  = "container"         // ContainerSchemaKey is the key to use container type filter schema.
-	PrometheusSchemaKey = "prometheus"        // PrometheusSchemaKey is the key to use prometheus type filter schema.
-	NodeSchemaKey       = "node"              // NodeSchemaKey is the key to use node type filter schema
-	LegacySchemaKey     = "legacy"            // LegacySchemaKey is the key to use legacy pod type filter schema.
-	PodType             = "k8s_pod"           // PodType is the resource value for pod type. (also used in the query)
-	ContainerType       = "k8s_container"     // ContainerType is the resource value for container type. (also used in the query)
-	NodeType            = "k8s_node"          // NodeType is the resource value for node type. (also used in the query)
-	PrometheusType      = "prometheus_target" // PrometheusType is the resource value for prometheus type. (also used in the query)
-	LegacyType          = "<not_allowed>"     // LegacyType is the resource value for legacy type. (NOT used in the query)
+	PodSchemaKey          = "pod"                   // PodSchemaKey is the key to use pod type filter schema.
+	PodContainerSchemaKey = "pod_container"         // PodContainerSchemaKey is the key to use pod or container type filter schema.
+	ContainerSchemaKey    = "container"             // ContainerSchemaKey is the key to use container type filter schema.
+	PrometheusSchemaKey   = "prometheus"            // PrometheusSchemaKey is the key to use prometheus type filter schema.
+	NodeSchemaKey         = "node"                  // NodeSchemaKey is the key to use node type filter schema
+	LegacySchemaKey       = "legacy"                // LegacySchemaKey is the key to use legacy pod type filter schema.
+	PodType               = "k8s_pod"               // PodType is the resource value for pod type. (also used in the query)
+	PodContainerType      = "k8s_pod,k8s_container" // PodContainerType is the resource value for pod or container type. (also used in the query)
+	ContainerType         = "k8s_container"         // ContainerType is the resource value for container type. (also used in the query)
+	NodeType              = "k8s_node"              // NodeType is the resource value for node type. (also used in the query)
+	PrometheusType        = "prometheus_target"     // PrometheusType is the resource value for prometheus type. (also used in the query)
+	LegacyType            = "<not_allowed>"         // LegacyType is the resource value for legacy type. (NOT used in the query)
 )
 
 var (
@@ -44,6 +46,9 @@ var (
 		namespace:    "resource.labels.namespace_name",
 		pods:         "resource.labels.pod_name",
 	}
+	// PodContainerSchema is the predefined schema for building pod/container type queries,
+	// and it uses the same schema as pod type.
+	PodContainerSchema = PodSchema
 	// ContainerSchema is the predefined schema for building container type queries,
 	// and it uses the same schema as pod type.
 	ContainerSchema = PodSchema
@@ -79,11 +84,12 @@ var (
 	}
 	// SchemaTypes is a collection of all FilterBuilder supported resource types for external uses.
 	SchemaTypes = map[string]string{
-		PodSchemaKey:        PodType,
-		ContainerSchemaKey:  ContainerType,
-		PrometheusSchemaKey: PrometheusType,
-		NodeSchemaKey:       NodeType,
-		LegacySchemaKey:     LegacyType,
+		PodSchemaKey:          PodType,
+		PodContainerSchemaKey: PodContainerType,
+		ContainerSchemaKey:    ContainerType,
+		PrometheusSchemaKey:   PrometheusType,
+		NodeSchemaKey:         NodeType,
+		LegacySchemaKey:       LegacyType,
 	}
 )
 
@@ -107,8 +113,8 @@ func NewFilterBuilder(resourceType string) FilterBuilder {
 	switch resourceType {
 	case PodType:
 		schema = PodSchema
-	case ContainerType:
-		schema = ContainerSchema
+	case PodContainerType:
+		schema = PodContainerSchema
 	case PrometheusType:
 		schema = PrometheusSchema
 	case NodeType:
@@ -121,7 +127,11 @@ func NewFilterBuilder(resourceType string) FilterBuilder {
 	filters := []string{}
 	// in legacy resource model, it doesn't use resource.type
 	if resourceType != LegacyType && schema.resourceType != "" {
-		filters = append(filters, fmt.Sprintf("%s = %q", schema.resourceType, resourceType))
+		if strings.Contains(resourceType, ",") {
+			filters = append(filters, fmt.Sprintf("%s = one_of(%s)", schema.resourceType, resourceType))
+		} else {
+			filters = append(filters, fmt.Sprintf("%s = %q", schema.resourceType, resourceType))
+		}
 	}
 	return FilterBuilder{
 		schema:  schema,

--- a/custom-metrics-stackdriver-adapter/pkg/adapter/translator/utils/filter_builder_test.go
+++ b/custom-metrics-stackdriver-adapter/pkg/adapter/translator/utils/filter_builder_test.go
@@ -52,6 +52,12 @@ func TestNewFilterBuilder_pod(t *testing.T) {
 	expectFilterBuilder(actual).toEqual(expected).report(t)
 }
 
+func TestNewFilterBuilder_pod_container(t *testing.T) {
+	actual := NewFilterBuilder(SchemaTypes["pod_container"])
+	expected := FilterBuilder{schema: PodSchema, filters: []string{"resource.type = one_of(k8s_pod,k8s_container)"}}
+	expectFilterBuilder(actual).toEqual(expected).report(t)
+}
+
 func TestNewFilterBuilder_legacy(t *testing.T) {
 	actual := NewFilterBuilder(SchemaTypes["legacy"])
 	expected := FilterBuilder{schema: LegacyPodSchema, filters: []string{}}


### PR DESCRIPTION
The main idea here is to avoid failure when querying pod level metrics throw an error. For example for the metric type is `kubernetes.io/container/accelerator/duty_cycle`, this query:
```
metric.type = "kubernetes.io/container/accelerator/duty_cycle" AND resource.type = "k8s_pod"
```

Throws the following error:
```
The supplied filter does not specify a valid combination of metric and monitored resource descriptors. 
The query will not return any time series.
```

Which makes the adapter return an error before trying to query the metrics using the `k8s_container`.


The proposed solution for this is to add a new resource type called `PodContainerType` for which we use the operator `one_of` to handle the fallback logic. However, given that the response might contain both `k8s_pod` and `k8s_container` metrics (time series), we're adding a post-processing step to consider `k8s_container` metrics if `k8s_pod` metrics are absent.

Also, to support resource label filters for custom metrics, we're adding `resource.labels` to the list of allowed prefixes for custom metrics.