### PR TITLE
event-exporter: bump version to 0.5.0

### DIFF
--- a/event-exporter/Makefile
+++ b/event-exporter/Makefile
@@ -20,7 +20,7 @@ ALL_ARCH=amd64 arm64
 IMAGE_NAME = event-exporter
 
 PREFIX ?= staging-k8s.gcr.io
-TAG ?= v0.4.5
+TAG ?= v0.5.0
 
 IMAGE=$(PREFIX)/$(IMAGE_NAME)
 


### PR DESCRIPTION
To release the pod owner label feature.

Change-Id: I877d7be0cfb6358bd769d80ca12c57efd05bc18e