### PR TITLE
skip certain memory metrics when not available

### DIFF
--- a/kubelet-to-gcm/monitor/kubelet/translate.go
+++ b/kubelet-to-gcm/monitor/kubelet/translate.go
@@ -525,34 +525,28 @@ func translateMemory(memory *stats.MemoryStats, tsFactory *timeSeriesFactory, st
 
 	// Only send page fault metric if start time is before current time. Right after container is started, kubelet can return start time == end time.
 	if pageFaultsMD != nil && memory.Time.Time.After(startTime) {
-		if memory.MajorPageFaults == nil {
-			return nil, fmt.Errorf("MajorPageFaults missing in MemoryStats %v", memory)
+		if memory.MajorPageFaults != nil {
+			// Major page faults.
+			majorPFPoint := tsFactory.newPoint(&v3.TypedValue{
+				Int64Value:      monitor.Int64Ptr(int64(*memory.MajorPageFaults)),
+				ForceSendFields: []string{"Int64Value"},
+			}, startTime, memory.Time.Time, pageFaultsMD.MetricKind)
+			timeSeries = append(timeSeries, tsFactory.newTimeSeries(majorPageFaultLabels, pageFaultsMD, majorPFPoint))
 		}
-		if memory.PageFaults == nil {
-			return nil, fmt.Errorf("PageFaults missing in MemoryStats %v", memory)
+		if memory.PageFaults != nil {
+			// Minor page faults.
+			minorPFPoint := tsFactory.newPoint(&v3.TypedValue{
+				Int64Value:      monitor.Int64Ptr(int64(*memory.PageFaults - *memory.MajorPageFaults)),
+				ForceSendFields: []string{"Int64Value"},
+			}, startTime, memory.Time.Time, pageFaultsMD.MetricKind)
+			timeSeries = append(timeSeries, tsFactory.newTimeSeries(minorPageFaultLabels, pageFaultsMD, minorPFPoint))
 		}
-		// Major page faults.
-		majorPFPoint := tsFactory.newPoint(&v3.TypedValue{
-			Int64Value:      monitor.Int64Ptr(int64(*memory.MajorPageFaults)),
-			ForceSendFields: []string{"Int64Value"},
-		}, startTime, memory.Time.Time, pageFaultsMD.MetricKind)
-		timeSeries = append(timeSeries, tsFactory.newTimeSeries(majorPageFaultLabels, pageFaultsMD, majorPFPoint))
-		// Minor page faults.
-		minorPFPoint := tsFactory.newPoint(&v3.TypedValue{
-			Int64Value:      monitor.Int64Ptr(int64(*memory.PageFaults - *memory.MajorPageFaults)),
-			ForceSendFields: []string{"Int64Value"},
-		}, startTime, memory.Time.Time, pageFaultsMD.MetricKind)
-		timeSeries = append(timeSeries, tsFactory.newTimeSeries(minorPageFaultLabels, pageFaultsMD, minorPFPoint))
 	}
 
 	if memUsedMD != nil {
 		if memory.WorkingSetBytes == nil {
 			return nil, fmt.Errorf("WorkingSetBytes information missing in MemoryStats %v", memory)
 		}
-		if memory.UsageBytes == nil {
-			return nil, fmt.Errorf("UsageBytes information missing in MemoryStats %v", memory)
-		}
-
 		// Non-evictable memory.
 		nonEvictMemPoint := tsFactory.newPoint(&v3.TypedValue{
 			Int64Value:      monitor.Int64Ptr(int64(*memory.WorkingSetBytes)),
@@ -564,16 +558,18 @@ func translateMemory(memory *stats.MemoryStats, tsFactory *timeSeriesFactory, st
 		}
 		timeSeries = append(timeSeries, tsFactory.newTimeSeries(labels, memUsedMD, nonEvictMemPoint))
 
-		// Evictable memory.
-		evictMemPoint := tsFactory.newPoint(&v3.TypedValue{
-			Int64Value:      monitor.Int64Ptr(int64(*memory.UsageBytes - *memory.WorkingSetBytes)),
-			ForceSendFields: []string{"Int64Value"},
-		}, startTime, memory.Time.Time, memUsedMD.MetricKind)
-		labels = map[string]string{"memory_type": "evictable"}
-		if component != "" {
-			labels["component"] = component
+		if memory.UsageBytes != nil {
+			// Evictable memory.
+			evictMemPoint := tsFactory.newPoint(&v3.TypedValue{
+				Int64Value:      monitor.Int64Ptr(int64(*memory.UsageBytes - *memory.WorkingSetBytes)),
+				ForceSendFields: []string{"Int64Value"},
+			}, startTime, memory.Time.Time, memUsedMD.MetricKind)
+			labels = map[string]string{"memory_type": "evictable"}
+			if component != "" {
+				labels["component"] = component
+			}
+			timeSeries = append(timeSeries, tsFactory.newTimeSeries(labels, memUsedMD, evictMemPoint))
 		}
-		timeSeries = append(timeSeries, tsFactory.newTimeSeries(labels, memUsedMD, evictMemPoint))
 	}
 
 	if memTotalMD != nil {

--- a/kubelet-to-gcm/monitor/kubelet/translate_test.go
+++ b/kubelet-to-gcm/monitor/kubelet/translate_test.go
@@ -154,6 +154,96 @@ const (
         }
     ]
 }`
+
+	incompleteContainerMemStatJSON = `{
+    "podRef": {
+        "name": "auditproxy-gke-12345678-1248-332a-vm",
+        "namespace": "kube-system",
+        "uid": "43780f1ce6e2171bc9e70cae3118ab6b"
+    },
+    "startTime": "2025-04-06T11:28:17Z",
+    "containers": [
+        {
+            "name": "auditproxy",
+            "startTime": "2025-04-23T15:17:45Z",
+            "cpu": {
+                "time": "2025-04-29T15:24:11Z",
+                "usageNanoCores": 12352231,
+                "usageCoreNanoSeconds": 4106274919000
+            },
+            "memory": {
+                "time": "2025-04-29T15:24:11Z",
+                "workingSetBytes": 76451840
+            },
+            "rootfs": {
+                "time": "2025-04-29T15:24:04Z",
+                "availableBytes": 4546961408,
+                "capacityBytes": 16656896000,
+                "usedBytes": 57344,
+                "inodesFree": 963008,
+                "inodes": 1036320,
+                "inodesUsed": 18
+            },
+            "logs": {
+                "time": "2025-04-29T15:24:11Z",
+                "availableBytes": 4546961408,
+                "capacityBytes": 16656896000,
+                "usedBytes": 44961792,
+                "inodesFree": 963008,
+                "inodes": 1036320,
+                "inodesUsed": 9
+            },
+            "swap": {
+                "time": "2025-04-29T15:24:11Z",
+                "swapAvailableBytes": 0,
+                "swapUsageBytes": 0
+            }
+        }
+    ],
+    "cpu": {
+        "time": "2025-04-29T15:23:59Z",
+        "usageNanoCores": 7444062,
+        "usageCoreNanoSeconds": 15900193844000
+    },
+    "memory": {
+        "time": "2025-04-29T15:23:59Z",
+        "usageBytes": 91631616,
+        "workingSetBytes": 88707072,
+        "rssBytes": 70098944,
+        "pageFaults": 63466572,
+        "majorPageFaults": 2461
+    },
+    "network": {
+        "time": "2025-04-29T15:24:07Z",
+        "name": "eth0",
+        "rxBytes": 208635268392,
+        "rxErrors": 0,
+        "txBytes": 939343805472,
+        "txErrors": 0,
+        "interfaces": [
+            {
+                "name": "eth0",
+                "rxBytes": 208635268392,
+                "rxErrors": 0,
+                "txBytes": 939343805472,
+                "txErrors": 0
+            }
+        ]
+    },
+    "ephemeral-storage": {
+        "time": "2025-04-29T15:24:11Z",
+        "availableBytes": 4546961408,
+        "capacityBytes": 16656896000,
+        "usedBytes": 45023232,
+        "inodesFree": 963008,
+        "inodes": 1036320,
+        "inodesUsed": 28
+    },
+    "swap": {
+        "time": "2025-04-29T15:23:59Z",
+        "swapUsageBytes": 0
+    }
+}`
 )
 
 // TestTranslator
@@ -226,6 +316,10 @@ func TestTranslateContainers(t *testing.T) {
 	badTimestampOnCumulativeMetricsContrainer.CPU.Time = badTimestampOnCumulativeMetricsContrainer.StartTime
 	legacyTsPerContainer := 11
 	tsPerContainer := 8
+	inCompleteContainerMemPodStat := &stats.PodStats{}
+	if err := json.Unmarshal([]byte(incompleteContainerMemStatJSON), inCompleteContainerMemPodStat); err != nil {
+		t.Errorf("Failed to unmarshal incompleteContainerMemStatJSON, err: %v", err)
+	}
 	testCases := []struct {
 		name                  string
 		ExpectedLegacyTSCount int
@@ -319,6 +413,12 @@ func TestTranslateContainers(t *testing.T) {
 					badTimestampOnCumulativeMetricsContrainer,
 				),
 			},
+		},
+		{
+			name:                  "inCompleteContainerMemPodStat missing memory usageBytes pageFaults, and majorPageFaults",
+			ExpectedLegacyTSCount: 7,
+			ExpectedTSCount:       4,
+			pods:                  []stats.PodStats{*inCompleteContainerMemPodStat},
 		},
 	}
 


### PR DESCRIPTION
Sometimes kubelet response on its /stats/summary endpoint can have missing data for `usageBytes` `pageFaults`, and `majorPageFaults` for container memory.

This change would skip those fields when unavailable, in stead of failing all metrics on that container.