### PR TITLE
Fix: Remove namespace from ClusterRole in adapter deployments

### DIFF
--- a/custom-metrics-stackdriver-adapter/deploy/production/adapter_new_resource_model.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/production/adapter_new_resource_model.yaml
@@ -40,7 +40,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: custom-metrics-resource-reader
-  namespace: custom-metrics
 rules:
 - apiGroups:
   - ""

--- a/custom-metrics-stackdriver-adapter/deploy/staging/adapter_new_resource_model.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/staging/adapter_new_resource_model.yaml
@@ -44,7 +44,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: custom-metrics-resource-reader
-  namespace: custom-metrics
 rules:
 - apiGroups:
   - ""

--- a/custom-metrics-stackdriver-adapter/deploy/staging/adapter_new_resource_model_external_cache.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/staging/adapter_new_resource_model_external_cache.yaml
@@ -44,7 +44,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: custom-metrics-resource-reader
-  namespace: custom-metrics
 rules:
   - apiGroups:
       - ""

--- a/custom-metrics-stackdriver-adapter/deploy/test/adapter_new_resource_model_with_core_metrics.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/test/adapter_new_resource_model_with_core_metrics.yaml
@@ -44,7 +44,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: custom-metrics-resource-reader
-  namespace: custom-metrics
 rules:
 - apiGroups:
   - ""


### PR DESCRIPTION
Removes the `namespace` field from ClusterRole definitions in the adapter's deployment YAML files. ClusterRoles are cluster-scoped resources and should not have a namespace.

Fixes #492