### PR TITLE
Remove `Options.Limit=1` with a flag guarded for this change 

### DIFF
--- a/event-exporter/event_exporter.go
+++ b/event-exporter/event_exporter.go
@@ -37,18 +37,19 @@ func (e *eventExporter) Run(stopCh <-chan struct{}) {
 	utils.RunConcurrentlyUntil(stopCh, e.sink.Run, e.watcher.Run)
 }
 
-func newEventExporter(client kubernetes.Interface, sink sinks.Sink, resyncPeriod time.Duration, eventLabelSelector labels.Selector) *eventExporter {
+func newEventExporter(client kubernetes.Interface, sink sinks.Sink, resyncPeriod time.Duration, eventLabelSelector labels.Selector, enableRemoveOptionsLimit bool) *eventExporter {
 	return &eventExporter{
 		sink:    sink,
-		watcher: createWatcher(client, sink, resyncPeriod, eventLabelSelector),
+		watcher: createWatcher(client, sink, resyncPeriod, eventLabelSelector, enableRemoveOptionsLimit),
 	}
 }
 
-func createWatcher(client kubernetes.Interface, sink sinks.Sink, resyncPeriod time.Duration, eventLabelSelector labels.Selector) watchers.Watcher {
+func createWatcher(client kubernetes.Interface, sink sinks.Sink, resyncPeriod time.Duration, eventLabelSelector labels.Selector, enableRemoveOptionsLimit bool) watchers.Watcher {
 	return events.NewEventWatcher(client, &events.EventWatcherConfig{
-		OnList:             sink.OnList,
-		ResyncPeriod:       resyncPeriod,
-		Handler:            sink,
-		EventLabelSelector: eventLabelSelector,
+		OnList:                   sink.OnList,
+		ResyncPeriod:             resyncPeriod,
+		Handler:                  sink,
+		EventLabelSelector:       eventLabelSelector,
+		EnableRemoveOptionsLimit: enableRemoveOptionsLimit,
 	})
 }

--- a/event-exporter/main.go
+++ b/event-exporter/main.go
@@ -45,12 +45,13 @@ var (
 	systemNamespaces = flag.String("system-namespaces", "kube-system,gke-connect", "Comma "+
 		"separated list of system namespaces to skip the owner label collection")
 
-	enablePodOwnerLabel    = flag.Bool("enable-pod-owner-label", true, "Whether to enable the pod label collector to add pod owner labels to log entries")
-	podCacheSize           = flag.Int("pod-label-cache-size", 2048, "When enable-pod-owner-label, the maximum number of pods in the label cache")
-	emptyLabelPodCacheSize = flag.Int("pod-empty-label-cache-size", 4096, "When enable-pod-owner-label, the maximum number of cached pods with empty label, to prevent repeated checks")
-	emptyLabelPodCacheTTL  = flag.Duration("pod-empty-label-cache-ttl", 2*time.Hour, "When enable-pod-owner-label, for pods with empty label, how long to keep their cache before checking again")
-	getPodTimeout          = flag.Duration("pod-get-timeout", 3*time.Second, "When enable-pod-owner-label, the timeout when getting pod labels")
-	eventLabelSelector     = flag.String("event-label-selector", "", "Export events only if they match the given label selector. Same syntax as kubectl label")
+	enablePodOwnerLabel      = flag.Bool("enable-pod-owner-label", true, "Whether to enable the pod label collector to add pod owner labels to log entries")
+	podCacheSize             = flag.Int("pod-label-cache-size", 2048, "When enable-pod-owner-label, the maximum number of pods in the label cache")
+	emptyLabelPodCacheSize   = flag.Int("pod-empty-label-cache-size", 4096, "When enable-pod-owner-label, the maximum number of cached pods with empty label, to prevent repeated checks")
+	emptyLabelPodCacheTTL    = flag.Duration("pod-empty-label-cache-ttl", 2*time.Hour, "When enable-pod-owner-label, for pods with empty label, how long to keep their cache before checking again")
+	getPodTimeout            = flag.Duration("pod-get-timeout", 3*time.Second, "When enable-pod-owner-label, the timeout when getting pod labels")
+	eventLabelSelector       = flag.String("event-label-selector", "", "Export events only if they match the given label selector. Same syntax as kubectl label")
+	enableRemoveOptionsLimit = flag.Bool("enable-remove-options-limit", false, "When enable-remove-options-limit, `options.Limit=1` at kubernetes/watchers/events/watcher.go will be removed.")
 )
 
 func newSystemStopChannel() chan struct{} {
@@ -106,7 +107,7 @@ func main() {
 	if err != nil {
 		glog.Fatalf("Invalid event label selector:%v", err)
 	}
-	eventExporter := newEventExporter(client, sink, *resyncPeriod, parsedLabelSelector)
+	eventExporter := newEventExporter(client, sink, *resyncPeriod, parsedLabelSelector, *enableRemoveOptionsLimit)
 
 	// Expose the Prometheus http endpoint
 	go func() {


### PR DESCRIPTION
Remove [Options.Limit=1](https://github.com/GoogleCloudPlatform/k8s-stackdriver/blob/master/event-exporter/kubernetes/watchers/events/watcher.go#L76) when flag `enableRemoveOptionsLimit` flag is enabled. Default value is false.