### PR TITLE
docs: clarify that stackdriver adapter is for end-users

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > :exclamation: **Most tools in this repository are not meant for end-users.**
 > It contains source code for tools that are pre-installed in the GKE clusters.
 > An exception to this is the [Custom Metrics - Stackdriver Adapter](custom-metrics-stackdriver-adapter),
-> which is meant for end-user consumption.
+> which is meant for [end-user consumption][stackdriverAdapter].
 
 [Google Cloud Operations suite][cloudOperationsSite] (fka Stackdriver) provides advanced 
 monitoring and logging solution that will allow you to get more
@@ -13,3 +13,4 @@ with Cloud Monitoring and Logging out of the box.
 
 [k8sMonitoring]: https://cloud.google.com/kubernetes-engine-monitoring
 [cloudOperationsSite]: https://cloud.google.com/products/operations 
+[stackdriverAdapter]: https://cloud.google.com/kubernetes-engine/docs/tutorials/autoscaling-metrics

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 ## Google Cloud Operations integration for GKE
 
-> :exclamation: **Tools in this repository are not meant for 
-> end-users.**
-> It contains source code for tools that are pre-installed in 
-> the GKE clusters.
+> :exclamation: **Most tools in this repository are not meant for end-users.**
+> It contains source code for tools that are pre-installed in the GKE clusters.
+> An exception to this is the [Custom Metrics - Stackdriver Adapter](custom-metrics-stackdriver-adapter),
+> which is meant for end-user consumption.
 
 [Google Cloud Operations suite][cloudOperationsSite] (fka Stackdriver) provides advanced 
 monitoring and logging solution that will allow you to get more


### PR DESCRIPTION
This has caused some confusion among users (see https://github.com/GoogleCloudPlatform/k8s-stackdriver/issues/480#issuecomment-2493956681).

Fixes https://github.com/GoogleCloudPlatform/k8s-stackdriver/issues/480.