### PR TITLE
Override tenant_uid value in monitored resource even if it is non-empty

### DIFF
--- a/prometheus-to-sd/Makefile
+++ b/prometheus-to-sd/Makefile
@@ -18,7 +18,7 @@ ENVVAR = GOOS=linux GOARCH=amd64 CGO_ENABLED=0
 IMAGE_NAME=prometheus-to-sd
 ALL_ARCH=amd64 arm64
 PREFIX ?= staging-k8s.gcr.io
-TAG ?= v0.12.4
+TAG ?= v0.12.5
 
 IMAGE=$(PREFIX)/$(IMAGE_NAME)
 

--- a/prometheus-to-sd/translator/translator.go
+++ b/prometheus-to-sd/translator/translator.go
@@ -560,7 +560,7 @@ func getCustomMonitoredResource(config *config.CommonConfig, tenantUID string) *
 	applyDefaultIfEmpty(resourceLabels, "cluster_name", config.GceConfig.Cluster)
 	applyDefaultIfEmpty(resourceLabels, "location", config.GceConfig.ClusterLocation)
 	applyDefaultIfEmpty(resourceLabels, "node_name", config.GceConfig.Instance)
-	applyDefaultIfEmpty(resourceLabels, "tenant_uid", tenantUID)
+	applyDefaultIfFound(resourceLabels, "tenant_uid", tenantUID)
 	return &monitoredres.MonitoredResource{
 		Type:   config.SourceConfig.CustomResourceType,
 		Labels: resourceLabels,
@@ -569,6 +569,12 @@ func getCustomMonitoredResource(config *config.CommonConfig, tenantUID string) *
 
 func applyDefaultIfEmpty(resourceLabels map[string]string, key, defaultValue string) {
 	if val, found := resourceLabels[key]; found && val == "" {
+		resourceLabels[key] = defaultValue
+	}
+}
+
+func applyDefaultIfFound(resourceLabels map[string]string, key, defaultValue string) {
+	if _, found := resourceLabels[key]; found {
 		resourceLabels[key] = defaultValue
 	}
 }

--- a/prometheus-to-sd/translator/translator_test.go
+++ b/prometheus-to-sd/translator/translator_test.go
@@ -563,7 +563,7 @@ func TestGetMonitoredResourceFromLabels(t *testing.T) {
 						"location":     "",
 						"instance_id":  "",
 						"node_name":    "",
-						"tenant_uid":   "",
+						"tenant_uid":   "old-tenant-uid",
 					},
 					PodConfig: config.NewPodConfig("", "", "", "", "", "tenantUIDLabel"),
 				},


### PR DESCRIPTION
Override tenant_uid value in monitored resource irrespective of whether or not the label was empty. If we don't do this then once the label value is set it is set forever for all future metrics which may or may not have the same tenant_uid value