### PR TITLE
Event-exporter lister watch memory improvement.

### DIFF
--- a/event-exporter/Makefile
+++ b/event-exporter/Makefile
@@ -20,7 +20,7 @@ ALL_ARCH=amd64 arm64
 IMAGE_NAME = event-exporter
 
 PREFIX ?= staging-k8s.gcr.io
-TAG ?= v0.5.6
+TAG ?= v0.5.7
 
 IMAGE=$(PREFIX)/$(IMAGE_NAME)
 

--- a/event-exporter/event_exporter.go
+++ b/event-exporter/event_exporter.go
@@ -37,19 +37,20 @@ func (e *eventExporter) Run(stopCh <-chan struct{}) {
 	utils.RunConcurrentlyUntil(stopCh, e.sink.Run, e.watcher.Run)
 }
 
-func newEventExporter(client kubernetes.Interface, sink sinks.Sink, resyncPeriod time.Duration, eventLabelSelector labels.Selector, enableRemoveOptionsLimit bool) *eventExporter {
+func newEventExporter(client kubernetes.Interface, sink sinks.Sink, resyncPeriod time.Duration, eventLabelSelector labels.Selector, listerWatcherOptionsLimit int64, storageType watchers.StorageType) *eventExporter {
 	return &eventExporter{
 		sink:    sink,
-		watcher: createWatcher(client, sink, resyncPeriod, eventLabelSelector, enableRemoveOptionsLimit),
+		watcher: createWatcher(client, sink, resyncPeriod, eventLabelSelector, listerWatcherOptionsLimit, storageType),
 	}
 }
 
-func createWatcher(client kubernetes.Interface, sink sinks.Sink, resyncPeriod time.Duration, eventLabelSelector labels.Selector, enableRemoveOptionsLimit bool) watchers.Watcher {
+func createWatcher(client kubernetes.Interface, sink sinks.Sink, resyncPeriod time.Duration, eventLabelSelector labels.Selector, listerWatcherOptionsLimit int64, storageType watchers.StorageType) watchers.Watcher {
 	return events.NewEventWatcher(client, &events.EventWatcherConfig{
-		OnList:                   sink.OnList,
-		ResyncPeriod:             resyncPeriod,
-		Handler:                  sink,
-		EventLabelSelector:       eventLabelSelector,
-		EnableRemoveOptionsLimit: enableRemoveOptionsLimit,
+		OnList:                    sink.OnList,
+		ResyncPeriod:              resyncPeriod,
+		Handler:                   sink,
+		EventLabelSelector:        eventLabelSelector,
+		ListerWatcherOptionsLimit: listerWatcherOptionsLimit,
+		StorageType:               storageType,
 	})
 }

--- a/event-exporter/kubernetes/podlabels/pod_labels_informer.go
+++ b/event-exporter/kubernetes/podlabels/pod_labels_informer.go
@@ -53,12 +53,19 @@ func NewPodLabelsSharedInformerFactory(client kubernetes.Interface, ignoredNames
 				if _, ok := ignoredNamespacesMap[pod.Namespace]; ok {
 					return nil, nil
 				}
+				labels := make(map[string]string)
+				if v, ok := pod.Labels["pod-template-hash"]; ok {
+					labels["pod-template-hash"] = v
+				}
+				if v, ok := pod.Labels[jobSetNameLabelKey]; ok {
+					labels[jobSetNameLabelKey] = v
+				}
 				return &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            pod.Name,
 						Namespace:       pod.Namespace,
 						OwnerReferences: pod.OwnerReferences,
-						Labels:          pod.Labels,
+						Labels:          labels,
 					},
 				}, nil
 			}),


### PR DESCRIPTION
Changes including:

1. Remove unused flag.
2. Change the flag `enableRemoveOptionsLimit` to `listerWatcherOptionsLimit` to allow configuration on number of options.limit. No limits when set to 0.
3. Support DeltaFIFO storage on event lister watcher.
4. Add flag `storageType` to allow configuring event-exporter lister watcher storage type.