### PR TITLE
copy the resource label map when setting tenant_uid

### DIFF
--- a/prometheus-to-sd/Makefile
+++ b/prometheus-to-sd/Makefile
@@ -18,7 +18,7 @@ ENVVAR = GOOS=linux GOARCH=amd64 CGO_ENABLED=0
 IMAGE_NAME=prometheus-to-sd
 ALL_ARCH=amd64 arm64
 PREFIX ?= staging-k8s.gcr.io
-TAG ?= v0.12.5
+TAG ?= v0.12.6
 
 IMAGE=$(PREFIX)/$(IMAGE_NAME)
 

--- a/prometheus-to-sd/translator/translator_test.go
+++ b/prometheus-to-sd/translator/translator_test.go
@@ -595,6 +595,9 @@ func TestGetMonitoredResourceFromLabels(t *testing.T) {
 			assert.Equal(t, tc.expectedType, monitoredResource.Type)
 			assert.Equal(t, tc.expectedLabels, monitoredResource.Labels)
 			assert.Equal(t, originalResourceLabelsInConfig, tc.config.MonitoredResourceLabels)
+			if val, ok := tc.config.SourceConfig.CustomLabels["tenant_uid"]; ok {
+				assert.NotEqual(t, tc.expectedLabels["tenant_uid"], val)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Need to clone the map because timeseries created using this label can have its label value overwritten by a newer value of tenant_uid before it was even exported since map would have pointed to the same address.