### PR TITLE
kubelet-to-gcm to have similar makefile as prometheus-to-sd

### DIFF
--- a/kubelet-to-gcm/Makefile
+++ b/kubelet-to-gcm/Makefile
@@ -15,8 +15,8 @@
 OUT_DIR = build
 PACKAGE = github.com/GoogleCloudPlatform/k8s-stackdriver/kubelet-to-gcm
 IMAGE_NAME = kubelet-to-gcm
-PREFIX = staging-k8s.gcr.io
-TAG = 1.4.1
+PREFIX ?= staging-k8s.gcr.io
+TAG ?= 1.4.1
 ALL_ARCH=amd64 arm64
 
 IMAGE=$(PREFIX)/$(IMAGE_NAME)


### PR DESCRIPTION
The multi-platform image upload configuration for prometheus-to-sd is know to work and should be replicated for ease of understanding. 