### PR TITLE
Move -$$arch suffix from image name to tag. Bump kubelet-to-gcm version to 1.4.4

### DIFF
--- a/kubelet-to-gcm/Makefile
+++ b/kubelet-to-gcm/Makefile
@@ -41,7 +41,6 @@ clean:
 	rm -rf build
 
 .container:
-	echo $(IMAGE):$(TAG)
 	docker buildx build . --pull -t $(IMAGE):$(TAG) $(BUILD_FLAGS) --load
 
 .sub-container-%:


### PR DESCRIPTION
By making images have the same name, but different tags make it easier for Google internal infrastructure to build them. 

It shouldn't affect any existing users of the image, as there will be a docker manifest pushed in place of the old image. 