### PR TITLE
Add restart attempt and uid labels for jobset events

### DIFF
--- a/event-exporter/kubernetes/podlabels/label_utils.go
+++ b/event-exporter/kubernetes/podlabels/label_utils.go
@@ -5,9 +5,11 @@ import (
 )
 
 const (
-	ownerTypeKeyName   = "logging.gke.io/top_level_controller_type"
-	ownerNameKeyName   = "logging.gke.io/top_level_controller_name"
-	jobSetNameLabelKey = "jobset.sigs.k8s.io/jobset-name"
+	ownerTypeKeyName             = "logging.gke.io/top_level_controller_type"
+	ownerNameKeyName             = "logging.gke.io/top_level_controller_name"
+	jobSetNameLabelKey           = "jobset.sigs.k8s.io/jobset-name"
+	jobSetRestartAttemptLabelKey = "jobset.sigs.k8s.io/restart-attempt"
+	jobsetUIDLabelKey            = "jobset.sigs.k8s.io/jobset-uid"
 )
 
 // matches suffixes containing number between 20000000 to 59999999

--- a/event-exporter/kubernetes/podlabels/pod_labels_informer.go
+++ b/event-exporter/kubernetes/podlabels/pod_labels_informer.go
@@ -121,6 +121,14 @@ func getLabelsFromPod(pod *corev1.Pod) map[string]string {
 				// Pod that is eventually owned by a JobSet has the jobset name label set.
 				transformedLabels[ownerTypeKeyName] = "JobSet"
 				transformedLabels[ownerNameKeyName] = jobsetName
+
+				// Add restart_attempt and uid labels for JobSet events.
+				if restartAttempt, ok := pod.GetObjectMeta().GetLabels()[jobSetRestartAttemptLabelKey]; ok {
+					transformedLabels[jobSetRestartAttemptLabelKey] = restartAttempt
+				}
+				if uid, ok := pod.GetObjectMeta().GetLabels()[jobsetUIDLabelKey]; ok {
+					transformedLabels[jobsetUIDLabelKey] = uid
+				}
 			} else {
 				transformedLabels[ownerTypeKeyName] = "Job"
 				transformedLabels[ownerNameKeyName] = owner.Name

--- a/event-exporter/kubernetes/podlabels/pod_labels_informer_test.go
+++ b/event-exporter/kubernetes/podlabels/pod_labels_informer_test.go
@@ -153,6 +153,26 @@ func TestGetLabelsFromPod(t *testing.T) {
 				"logging.gke.io/top_level_controller_name": "training-sample",
 			},
 		},
+		{
+			description: "correct jobset owner, restart attempt and uid labels returned for pod",
+			pod: makePod(mockPodOptions{
+				Labels: map[string]string{
+					"jobset.sigs.k8s.io/jobset-name":     "training-sample",
+					"jobset.sigs.k8s.io/restart-attempt": "5",
+					"jobset.sigs.k8s.io/jobset-uid":      "fake-uid",
+				},
+				OwnerReference: metav1.OwnerReference{
+					Kind: "Job",
+					Name: "training-sample-0",
+				},
+			}),
+			wantLabels: map[string]string{
+				"logging.gke.io/top_level_controller_type": "JobSet",
+				"logging.gke.io/top_level_controller_name": "training-sample",
+				"jobset.sigs.k8s.io/restart-attempt":       "5",
+				"jobset.sigs.k8s.io/jobset-uid":            "fake-uid",
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This PR extends the pod label extraction logic in the Event Exporter to support the `jobset.sigs.k8s.io/restart-attempt` and `jobset.sigs.k8s.io/jobset-uid` labels.

Previously, we only extracted the `jobset_name` for pod owner labels. By adding the `restart_attempt` and `uid`, we allow downstream consumers to clearly distinguish between events occurring across different restart attempts of the same JobSet. This is critical for accurate reliability metrics and debugging restart loops where events might overlap in time.