### PR TITLE
fluentd-gcp-scaler: switch base image to bookworm-v1.0.7

### DIFF
--- a/fluentd-gcp-scaler/Dockerfile
+++ b/fluentd-gcp-scaler/Dockerfile
@@ -15,7 +15,7 @@
 # This Dockerfile will build an image of a manual fluent-gcp scaler, allowing
 # customers to override our resource request/limit defaults.
 
-FROM gcr.io/k8s-staging-build-image/debian-base-amd64:buster-v1.3.0
+FROM gcr.io/k8s-staging-build-image/debian-base-amd64:bookworm-v1.0.7
 
 # Download latest stable version of kubectl
 RUN \


### PR DESCRIPTION
Replacement for Dependabot PR #556.

The original bump to `buster-v1.10.0` still failed to build because Debian buster apt repos are EOL.

This updates the base image to a supported tag:
- `gcr.io/k8s-staging-build-image/debian-base-amd64:bookworm-v1.0.7`

Validation in isolated worktree:
- `cd fluentd-gcp-scaler && make build`
