### PR TITLE
custom-metrics example: fix direct-to-sd docker build with Go 1.25

### DIFF
--- a/custom-metrics-stackdriver-adapter/examples/direct-to-sd/Dockerfile
+++ b/custom-metrics-stackdriver-adapter/examples/direct-to-sd/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.19-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## What
- Update `custom-metrics-stackdriver-adapter/examples/direct-to-sd/Dockerfile` builder image:
  - `golang:1.19-alpine` -> `golang:1.25-alpine`

## Why
`examples/direct-to-sd/go.mod` declares `go 1.23.0`. The previous builder image (`go1.19`) fails parsing that version during `go mod download`, which breaks `make docker` for this example.

## Validation
Validated in an isolated `upstream/master` worktree after this patch:
- `custom-metrics-stackdriver-adapter`: `make test`, `make build`, `make docker`
- `event-exporter`: `make test`, `make build`, `make container`
- `kubelet-to-gcm`: `make test`, `make compile`, `make .container`
- `prometheus-to-sd`: `make test`, `make build`, `make container`
- `fluentd-gcp-scaler`: `make build`
- `custom-metrics-stackdriver-adapter/examples/direct-to-sd`: `make docker`
- `custom-metrics-stackdriver-adapter/examples/prometheus-to-sd`: `make docker`
