### PR TITLE
custom-metrics-stackdriver-adapter: Fix GPU/TPU tolerations for GKE Autopilot compatibility

### DIFF
--- a/custom-metrics-stackdriver-adapter/adapter-beta.yaml
+++ b/custom-metrics-stackdriver-adapter/adapter-beta.yaml
@@ -73,10 +73,12 @@ spec:
       serviceAccountName: custom-metrics-stackdriver-adapter
       tolerations:
       - key: "nvidia.com/gpu"
-        operator: "Exists"
+        operator: "Equal"
+        value: "present"
         effect: "NoSchedule"
       - key: "cloud.google.com/gke-tpu"
-        operator: "Exists"
+        operator: "Equal"
+        value: "present"
         effect: "NoSchedule"
       containers:
       - image: gcr.io/google-containers/custom-metrics-stackdriver-adapter:v0.4.0

--- a/custom-metrics-stackdriver-adapter/deploy/production/adapter.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/production/adapter.yaml
@@ -73,10 +73,12 @@ spec:
       serviceAccountName: custom-metrics-stackdriver-adapter
       tolerations:
       - key: "nvidia.com/gpu"
-        operator: "Exists"
+        operator: "Equal"
+        value: "present"
         effect: "NoSchedule"
       - key: "cloud.google.com/gke-tpu"
-        operator: "Exists"
+        operator: "Equal"
+        value: "present"
         effect: "NoSchedule"
       containers:
       - image: gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.16.2-gke.0

--- a/custom-metrics-stackdriver-adapter/deploy/production/adapter_new_resource_model.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/production/adapter_new_resource_model.yaml
@@ -89,10 +89,12 @@ spec:
       serviceAccountName: custom-metrics-stackdriver-adapter
       tolerations:
       - key: "nvidia.com/gpu"
-        operator: "Exists"
+        operator: "Equal"
+        value: "present"
         effect: "NoSchedule"
       - key: "cloud.google.com/gke-tpu"
-        operator: "Exists"
+        operator: "Equal"
+        value: "present"
         effect: "NoSchedule"
       containers:
       - image: gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.16.2-gke.0

--- a/custom-metrics-stackdriver-adapter/deploy/staging/adapter_new_resource_model.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/staging/adapter_new_resource_model.yaml
@@ -93,10 +93,12 @@ spec:
       serviceAccountName: custom-metrics-stackdriver-adapter
       tolerations:
       - key: "nvidia.com/gpu"
-        operator: "Exists"
+        operator: "Equal"
+        value: "present"
         effect: "NoSchedule"
       - key: "cloud.google.com/gke-tpu"
-        operator: "Exists"
+        operator: "Equal"
+        value: "present"
         effect: "NoSchedule"
       containers:
       - image: gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.16.2-gke.0

--- a/custom-metrics-stackdriver-adapter/deploy/staging/adapter_old_resource_model.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/staging/adapter_old_resource_model.yaml
@@ -77,10 +77,12 @@ spec:
       serviceAccountName: custom-metrics-stackdriver-adapter
       tolerations:
       - key: "nvidia.com/gpu"
-        operator: "Exists"
+        operator: "Equal"
+        value: "present"
         effect: "NoSchedule"
       - key: "cloud.google.com/gke-tpu"
-        operator: "Exists"
+        operator: "Equal"
+        value: "present"
         effect: "NoSchedule"
       containers:
       - image: gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.16.2-gke.0

--- a/custom-metrics-stackdriver-adapter/deploy/test/adapter_new_resource_model_with_core_metrics.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/test/adapter_new_resource_model_with_core_metrics.yaml
@@ -93,10 +93,12 @@ spec:
       serviceAccountName: custom-metrics-stackdriver-adapter
       tolerations:
       - key: "nvidia.com/gpu"
-        operator: "Exists"
+        operator: "Equal"
+        value: "present"
         effect: "NoSchedule"
       - key: "cloud.google.com/gke-tpu"
-        operator: "Exists"
+        operator: "Equal"
+        value: "present"
         effect: "NoSchedule"
       containers:
       - image: gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.16.2-gke.0

--- a/custom-metrics-stackdriver-adapter/yaml_test.go
+++ b/custom-metrics-stackdriver-adapter/yaml_test.go
@@ -64,10 +64,10 @@ func checkTolerations(t *testing.T, deployment *appsv1.Deployment, file string) 
 	tpuFound := false
 
 	for _, tol := range tolerations {
-		if tol.Key == "nvidia.com/gpu" && tol.Operator == "Exists" && tol.Effect == "NoSchedule" {
+		if tol.Key == "nvidia.com/gpu" && tol.Operator == "Equal" && tol.Value == "present" && tol.Effect == "NoSchedule" {
 			gpuFound = true
 		}
-		if tol.Key == "cloud.google.com/gke-tpu" && tol.Operator == "Exists" && tol.Effect == "NoSchedule" {
+		if tol.Key == "cloud.google.com/gke-tpu" && tol.Operator == "Equal" && tol.Value == "present" && tol.Effect == "NoSchedule" {
 			tpuFound = true
 		}
 	}


### PR DESCRIPTION
#1078 added tolerations to allow scheduling to GPU/TPU nodes if they are the only type of nodes. However, GKE Autopilot rejects such tolerations if they don't request gpu/tpu resources. 

This is a workaround to bypass GKE Autopilot wehbook. We will follow up with GKE Autopilot to allowlist this component.