### PR TITLE
fix: resolve OpenAPI V3 build failure for custom/external metrics

### DIFF
--- a/custom-metrics-stackdriver-adapter/adapter.go
+++ b/custom-metrics-stackdriver-adapter/adapter.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/GoogleCloudPlatform/k8s-stackdriver/custom-metrics-stackdriver-adapter/pkg/adapter/translator"
@@ -190,12 +191,10 @@ func main() {
 	}
 
 	if cmd.OpenAPIConfig == nil {
-		cmd.OpenAPIConfig = genericapiserver.DefaultOpenAPIConfig(generatedopenapi.GetOpenAPIDefinitions, openapinamer.NewDefinitionNamer(api.Scheme, customexternalmetrics.Scheme))
+		namer := openapinamer.NewDefinitionNamer(api.Scheme, customexternalmetrics.Scheme)
+		cmd.OpenAPIConfig = genericapiserver.DefaultOpenAPIConfig(generatedopenapi.GetOpenAPIDefinitions, namer)
 		cmd.OpenAPIConfig.GetDefinitionName = func(name string) (string, openapispec.Extensions) {
-			if name == "k8s.io/apimachinery/pkg/version.Info" {
-				return version.Info{}.OpenAPIModelName(), nil
-			}
-			return openapinamer.NewDefinitionNamer(api.Scheme, customexternalmetrics.Scheme).GetDefinitionName(name)
+			return getDefinitionName(namer, name)
 		}
 		cmd.OpenAPIConfig.Info.Title = "custom-metrics-stackdriver-adapter"
 		cmd.OpenAPIConfig.Info.Version = "1.0.0"
@@ -278,6 +277,17 @@ func main() {
 	if err := cmd.Run(context.Background()); err != nil {
 		klog.Fatalf("unable to run custom metrics adapter: %v", err)
 	}
+}
+
+func getDefinitionName(namer *openapinamer.DefinitionNamer, name string) (string, openapispec.Extensions) {
+	if name == "k8s.io/apimachinery/pkg/version.Info" {
+		return version.Info{}.OpenAPIModelName(), nil
+	}
+	canonicalName := name
+	if strings.HasPrefix(name, "k8s.io/") {
+		canonicalName = "io.k8s." + strings.ReplaceAll(name[7:], "/", ".")
+	}
+	return namer.GetDefinitionName(canonicalName)
 }
 
 func runPrometheusMetricsServer(addr string) {

--- a/custom-metrics-stackdriver-adapter/adapter_test.go
+++ b/custom-metrics-stackdriver-adapter/adapter_test.go
@@ -17,7 +17,14 @@ limitations under the License.
 package main
 
 import (
+	"strings"
 	"testing"
+
+	generatedopenapi "github.com/GoogleCloudPlatform/k8s-stackdriver/custom-metrics-stackdriver-adapter/pkg/api/generated/openapi"
+	openapinamer "k8s.io/apiserver/pkg/endpoints/openapi"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+	customexternalmetrics "sigs.k8s.io/custom-metrics-apiserver/pkg/apiserver"
+	"sigs.k8s.io/metrics-server/pkg/api"
 )
 
 var urltests = []struct {
@@ -71,5 +78,22 @@ func TestURLValidator(t *testing.T) {
 				t.Errorf("for url %v got %v, expect %v", tc.url, result, tc.expect)
 			}
 		})
+	}
+}
+
+func TestOpenAPIDefinitionsResolution(t *testing.T) {
+	namer := openapinamer.NewDefinitionNamer(api.Scheme, customexternalmetrics.Scheme)
+	definitions := generatedopenapi.GetOpenAPIDefinitions(func(name string) spec.Ref {
+		return spec.Ref{}
+	})
+	for gvk, typ := range customexternalmetrics.Scheme.AllKnownTypes() {
+		if !strings.Contains(gvk.Group, "metrics.k8s.io") || gvk.Version == "__internal" {
+			continue
+		}
+		typeName := typ.PkgPath() + "." + typ.Name()
+		resolvedName, _ := getDefinitionName(namer, typeName)
+		if _, ok := definitions[resolvedName]; !ok {
+			t.Errorf("OpenAPI definition for GVK %v (type name %q resolved to %q) not found in generated definitions", gvk, typeName, resolvedName)
+		}
 	}
 }


### PR DESCRIPTION
Resolves an OpenAPI V3 schema building failure where the API aggregator
cannot find model definitions for custom and external metrics groups
(e.g., `io.k8s.metrics.pkg.apis.custom_metrics.v1beta2.MetricValueList`). Canonicalize incoming slash-separated `k8s.io/` names into dot-separated names.