### PR TITLE
Quote image reference variables in Makefile recipes

### DIFF
--- a/archived/fluentd-gcp-scaler/Makefile
+++ b/archived/fluentd-gcp-scaler/Makefile
@@ -21,8 +21,8 @@ PREFIX=staging-k8s.gcr.io
 TAG = 0.5.5
 
 build:
-	docker build --pull -t $(PREFIX)/fluentd-gcp-scaler:$(TAG) .
+	docker build --pull -t '$(PREFIX)/fluentd-gcp-scaler:$(TAG)' .
 
 
 push:
-	gcloud docker -- push $(PREFIX)/fluentd-gcp-scaler:$(TAG)
+	gcloud docker -- push '$(PREFIX)/fluentd-gcp-scaler:$(TAG)'

--- a/custom-metrics-stackdriver-adapter/Makefile
+++ b/custom-metrics-stackdriver-adapter/Makefile
@@ -14,10 +14,10 @@ build/adapter: adapter.go $(PKG)
 	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(ARCH) go build -mod readonly -a -o $(OUT_DIR)/$(ARCH)/adapter adapter.go
 
 docker:
-	docker buildx build . --pull --load -t ${PREFIX}/custom-metrics-stackdriver-adapter:$(TAG)
+	docker buildx build . --pull --load -t '${PREFIX}/custom-metrics-stackdriver-adapter:$(TAG)'
 
 push: docker
-	gcloud docker -- push ${PREFIX}/custom-metrics-stackdriver-adapter:$(TAG)
+	gcloud docker -- push '${PREFIX}/custom-metrics-stackdriver-adapter:$(TAG)'
 
 test: $(PKG)
 	CGO_ENABLED=0 go test -mod readonly ./...

--- a/event-exporter/Makefile
+++ b/event-exporter/Makefile
@@ -38,7 +38,7 @@ test:
 container: .container
 
 .container:
-	docker buildx build . --pull -t $(IMAGE):$(TAG) $(BUILD_FLAGS) --load
+	docker buildx build . --pull -t '$(IMAGE):$(TAG)' $(BUILD_FLAGS) --load
 
 .sub-container-%:
 	$(MAKE) --no-print-directory ARCH=$* .container
@@ -48,17 +48,17 @@ container-multiarch:  $(addprefix .sub-container-,$(ALL_ARCH))
 push: build .push
 
 .push: .container
-	docker push $(IMAGE):$(TAG)
+	docker push '$(IMAGE):$(TAG)'
 
 .sub-push-%:
 	$(MAKE) --no-print-directory ARCH=$* .push
 
 push-multiarch: build $(addprefix .sub-push-,$(ALL_ARCH))
-	docker manifest create --amend $(IMAGE):$(TAG) $(addsuffix :$(TAG),$(addprefix $(IMAGE)-,$(ALL_ARCH)))
+	docker manifest create --amend '$(IMAGE):$(TAG)' $(foreach arch,$(ALL_ARCH),'$(IMAGE)-$(arch):$(TAG)')
 	for arch in $(ALL_ARCH); do \
-	  docker manifest annotate --os=linux --arch=$$arch $(IMAGE):$(TAG) $(IMAGE)-$$arch:$(TAG); \
+	  docker manifest annotate --os=linux --arch=$$arch '$(IMAGE):$(TAG)' '$(IMAGE)-'$$arch':$(TAG)'; \
 	done
-	docker manifest push -p $(IMAGE):$(TAG)
+	docker manifest push -p '$(IMAGE):$(TAG)'
 
 clean:
 	rm -rf ${BINARY_NAME}

--- a/kubelet-to-gcm/Makefile
+++ b/kubelet-to-gcm/Makefile
@@ -41,7 +41,7 @@ clean:
 	rm -rf build
 
 .container:
-	docker buildx build . --pull -t $(IMAGE):$(TAG) $(BUILD_FLAGS) --load
+	docker buildx build . --pull -t '$(IMAGE):$(TAG)' $(BUILD_FLAGS) --load
 
 .sub-container-%:
 	$(MAKE) --no-print-directory ARCH=$* .container
@@ -49,7 +49,7 @@ clean:
 container-multiarch:  $(addprefix .sub-container-,$(ALL_ARCH))
 
 .push: .container
-	docker push $(IMAGE):$(TAG)
+	docker push '$(IMAGE):$(TAG)'
 
 push: .push
 
@@ -57,11 +57,11 @@ push: .push
 	$(MAKE) --no-print-directory ARCH=$* .push
 
 push-multiarch: $(addprefix .sub-push-,$(ALL_ARCH))
-	docker manifest create --amend $(IMAGE):$(TAG) $(addprefix $(IMAGE):$(TAG)-, $(ALL_ARCH))
+	docker manifest create --amend '$(IMAGE):$(TAG)' $(foreach arch,$(ALL_ARCH),'$(IMAGE):$(TAG)-$(arch)')
 	for arch in $(ALL_ARCH); do \
-	  docker manifest annotate --os=linux --arch=$$arch $(IMAGE):$(TAG) $(IMAGE):$(TAG)-$$arch; \
+	  docker manifest annotate --os=linux --arch=$$arch '$(IMAGE):$(TAG)' '$(IMAGE):$(TAG)-'$$arch; \
 	done
-	docker manifest push -p $(IMAGE):$(TAG)
+	docker manifest push -p '$(IMAGE):$(TAG)'
 
 clean:
 	rm -rf monitor

--- a/prometheus-to-sd/Makefile
+++ b/prometheus-to-sd/Makefile
@@ -36,7 +36,7 @@ test:
 container: .container
 
 .container:
-	docker buildx build . --pull -t $(IMAGE):$(TAG) $(BUILD_FLAGS) --load
+	docker buildx build . --pull -t '$(IMAGE):$(TAG)' $(BUILD_FLAGS) --load
 
 .sub-container-%:
 	$(MAKE) --no-print-directory ARCH=$* .container
@@ -46,17 +46,17 @@ container-multiarch:  $(addprefix .sub-container-,$(ALL_ARCH))
 push: .push
 
 .push: .container
-	docker push $(IMAGE):$(TAG)
+	docker push '$(IMAGE):$(TAG)'
 
 .sub-push-%:
 	$(MAKE) --no-print-directory ARCH=$* .push
 
 push-multiarch: $(addprefix .sub-push-,$(ALL_ARCH))
-	docker manifest create --amend $(IMAGE):$(TAG) $(addsuffix :$(TAG),$(addprefix $(IMAGE)-,$(ALL_ARCH)))
+	docker manifest create --amend '$(IMAGE):$(TAG)' $(foreach arch,$(ALL_ARCH),'$(IMAGE)-$(arch):$(TAG)')
 	for arch in $(ALL_ARCH); do \
-	  docker manifest annotate --os=linux --arch=$$arch $(IMAGE):$(TAG) $(IMAGE)-$$arch:$(TAG); \
+	  docker manifest annotate --os=linux --arch=$$arch '$(IMAGE):$(TAG)' '$(IMAGE)-'$$arch':$(TAG)'; \
 	done
-	docker manifest push -p $(IMAGE):$(TAG)
+	docker manifest push -p '$(IMAGE):$(TAG)'
 
 clean:
 	rm -rf monitor


### PR DESCRIPTION
## Summary

Wrap `$(IMAGE)`, `$(PREFIX)`, `$(TAG)`, and related image-reference interpolations in single quotes within the `docker` and `gcloud` invocations across the project Makefiles. These variables are declared with `?=` (or otherwise overridable on the command line), so their values flow through to the shell verbatim. Single-quoting passes them as literal arguments rather than letting the shell parse them.

Affects:

- `event-exporter/Makefile`
- `prometheus-to-sd/Makefile`
- `kubelet-to-gcm/Makefile`
- `custom-metrics-stackdriver-adapter/Makefile`
- `archived/fluentd-gcp-scaler/Makefile`

The `for arch in $(ALL_ARCH)` loops keep `$$arch` expansion intact by closing the surrounding single quotes around the shell variable reference.

## Test plan

- [x] `make -n` dry-run of each affected target with `TAG` / `PREFIX` overridden to a value containing shell metacharacters — the expanded recipe lines wrap the value in single quotes and pass it as a single argument to docker.
- [x] `for`-loop bodies still expand `$arch` correctly between the quoted segments.
- [ ] No behavioral change for normal `TAG`/`PREFIX` values used in release builds.