### PR TITLE
Validate authTokenFile path to prevent arbitrary file reads

### DIFF
--- a/prometheus-to-sd/config/common_config.go
+++ b/prometheus-to-sd/config/common_config.go
@@ -17,8 +17,10 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net/url"
+	"path/filepath"
 	"strings"
 
 	dto "github.com/prometheus/client_model/go"
@@ -114,6 +116,9 @@ func parseAuthConfig(url url.URL) (*AuthConfig, error) {
 	authPassword := values.Get("authPassword")
 
 	if len(authToken) == 0 && len(authTokenFile) > 0 {
+		if !isValidTokenFile(authTokenFile) {
+			return nil, fmt.Errorf("invalid authTokenFile path")
+		}
 		buff, err := ioutil.ReadFile(authTokenFile)
 		if err != nil {
 			return nil, err
@@ -126,4 +131,17 @@ func parseAuthConfig(url url.URL) (*AuthConfig, error) {
 		Password: authPassword,
 		Token:    authToken,
 	}, nil
+}
+
+func isValidTokenFile(path string) bool {
+	if path == "" || !filepath.IsAbs(path) {
+		return false
+	}
+	cleaned := filepath.Clean(path)
+	for _, prefix := range []string{"/var/run/secrets/", "/etc/secrets/", "/etc/prometheus/"} {
+		if strings.HasPrefix(cleaned, prefix) {
+			return true
+		}
+	}
+	return false
 }

--- a/prometheus-to-sd/config/common_config_test.go
+++ b/prometheus-to-sd/config/common_config_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2026 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsValidTokenFile(t *testing.T) {
+	tests := []struct {
+		path  string
+		valid bool
+	}{
+		{"/var/run/secrets/token", true},
+		{"/var/run/secrets/sub/token", true},
+		{"/etc/secrets/my-token", true},
+		{"/etc/prometheus/token", true},
+		{"/etc/passwd", false},
+		{"/var/run/secrets/../../etc/passwd", false},
+		{"relative/path", false},
+		{"", false},
+	}
+
+	for _, tc := range tests {
+		assert.Equal(t, tc.valid, isValidTokenFile(tc.path), "path: %s", tc.path)
+	}
+}
+
+func TestParseAuthConfigInvalidTokenFile(t *testing.T) {
+	u, _ := url.Parse("http://localhost?authTokenFile=/etc/passwd")
+	_, err := parseAuthConfig(*u)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid authTokenFile path")
+}


### PR DESCRIPTION
Add absolute path and safe prefix validation to the authTokenFile parameter parsed from metrics scraping URIs.