### PR TITLE
Resolve project from labelSelector before caching metrics

### DIFF
--- a/custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder.go
+++ b/custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder.go
@@ -519,18 +519,14 @@ func (t *Translator) ListMetricDescriptors(fallbackForContainerMetrics bool) *st
 // GetMetricKind returns metricKind for metric metricName, obtained from Stackdriver Monitoring API.
 func (t *Translator) GetMetricKind(metricName string, metricSelector labels.Selector) (string, string, error) {
 	metricProj := t.config.Project
-	cacheKey := metricKindCacheKey{
-		project: metricProj,
-		name:    metricName,
-	}
-	if value, ok := t.metricKindCache.get(cacheKey); ok {
-		return value.MetricKind, value.ValueType, nil
-	}
 
 	requirements, selectable := metricSelector.Requirements()
 	if !selectable {
 		return "", "", apierr.NewBadRequest(fmt.Sprintf("Label selector is impossible to match: %s", metricSelector))
 	}
+
+	// Resolve the target project ID from the label selectors (if any) before
+	// checking the metrics cache.
 	for _, req := range requirements {
 		if req.Key() == "resource.labels.project_id" {
 			if req.Operator() == selection.Equals || req.Operator() == selection.DoubleEquals {
@@ -540,6 +536,15 @@ func (t *Translator) GetMetricKind(metricName string, metricSelector labels.Sele
 			return "", "", NewLabelNotAllowedError(fmt.Sprintf("Project selector must use '=' or '==': You used %s", req.Operator()))
 		}
 	}
+
+	cacheKey := metricKindCacheKey{
+		project: metricProj,
+		name:    metricName,
+	}
+	if value, ok := t.metricKindCache.get(cacheKey); ok {
+		return value.MetricKind, value.ValueType, nil
+	}
+
 	response, err := t.service.Projects.MetricDescriptors.Get(fmt.Sprintf("projects/%s/metricDescriptors/%s", metricProj, metricName)).Do()
 	if err != nil {
 		return "", "", NewNoSuchMetricError(metricName, err)

--- a/custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go
+++ b/custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go
@@ -1542,3 +1542,46 @@ func TestQueryBuilder_Node_SingleWithMetricSelector_Distribution(t *testing.T) {
 		t.Errorf("Unexpected result. Expected: \n%v,\n received: \n%v", expectedRequest, request)
 	}
 }
+
+func TestTranslator_GetMetricKind_CacheKeyIsolation(t *testing.T) {
+	metricName := "custom.googleapis.com/metric_name"
+	metricKind := "CUMULATIVE"
+	customProject := "project-A"
+
+	// Cloud Monitoring service that returns custom.googleapis.com/metric_name
+	// metric descriptor for project-A
+	sdService := NewMockStackdriverService(t, &mockMetricKindRoundTripper{
+		wantMetricName:  metricName,
+		wantProjectName: customProject,
+		response: &sd.MetricDescriptor{
+			Type:       metricName,
+			MetricKind: metricKind,
+			ValueType:  "INT64",
+		},
+	})
+	cache := newMetricKindCache(2, 10*time.Minute)
+	translator := newFakeTranslatorForGetMetricKind(2*time.Minute, time.Minute, testProjectID, time.Date(2017, 1, 2, 13, 2, 0, 0, time.UTC), sdService, cache)
+
+	// Specify project selector in the metric selector that's different from
+	// the default project ID (testProjectID)
+	selector, _ := labels.Parse("resource.labels.project_id=" + customProject)
+	gotKind, _, err := translator.GetMetricKind(metricName, selector)
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	if gotKind != metricKind {
+		t.Errorf("GetMetricKind(%s, %v) metric kind = %q, want %q", metricName, selector, gotKind, metricKind)
+	}
+
+	// Verify it's cached under the correct customProject key
+	keyA := metricKindCacheKey{project: customProject, name: metricName}
+	if _, found := translator.metricKindCache.get(keyA); !found {
+		t.Errorf("metricKindCache.get(%v) = false, want true", keyA)
+	}
+
+	// Verify it is NOT cached under the default project key
+	keyDefault := metricKindCacheKey{project: testProjectID, name: metricName}
+	if _, found := translator.metricKindCache.get(keyDefault); found {
+		t.Errorf("metricKindCache.get(%v) = true, want false", keyDefault)
+	}
+}


### PR DESCRIPTION
This ensures that the metric value and type are correctly isolated by project ID. Today, metrics are always being cached by the default project ID, even if the query specifies a different project ID in the label selectors.