### PR TITLE
Fix custom metrics adapter OpenAPI v3 definitions

### DIFF
--- a/custom-metrics-stackdriver-adapter/adapter.go
+++ b/custom-metrics-stackdriver-adapter/adapter.go
@@ -34,8 +34,8 @@ import (
 	stackdriver "google.golang.org/api/monitoring/v3"
 	openapinamer "k8s.io/apiserver/pkg/endpoints/openapi"
 	genericapiserver "k8s.io/apiserver/pkg/server"
-	openapispec "k8s.io/kube-openapi/pkg/validation/spec"
 	coreclient "k8s.io/client-go/kubernetes/typed/core/v1"
+	openapispec "k8s.io/kube-openapi/pkg/validation/spec"
 	customexternalmetrics "sigs.k8s.io/custom-metrics-apiserver/pkg/apiserver"
 	"sigs.k8s.io/custom-metrics-apiserver/pkg/provider"
 
@@ -190,15 +190,7 @@ func main() {
 		},
 	}
 
-	if cmd.OpenAPIConfig == nil {
-		namer := openapinamer.NewDefinitionNamer(api.Scheme, customexternalmetrics.Scheme)
-		cmd.OpenAPIConfig = genericapiserver.DefaultOpenAPIConfig(generatedopenapi.GetOpenAPIDefinitions, namer)
-		cmd.OpenAPIConfig.GetDefinitionName = func(name string) (string, openapispec.Extensions) {
-			return getDefinitionName(namer, name)
-		}
-		cmd.OpenAPIConfig.Info.Title = "custom-metrics-stackdriver-adapter"
-		cmd.OpenAPIConfig.Info.Version = "1.0.0"
-	}
+	configureOpenAPI(cmd)
 
 	flags := cmd.Flags()
 	klog.InitFlags(flag.CommandLine)
@@ -276,6 +268,27 @@ func main() {
 	}
 	if err := cmd.Run(context.Background()); err != nil {
 		klog.Fatalf("unable to run custom metrics adapter: %v", err)
+	}
+}
+
+func configureOpenAPI(cmd *StackdriverAdapter) {
+	namer := openapinamer.NewDefinitionNamer(api.Scheme, customexternalmetrics.Scheme)
+	resolveDefinitionName := func(name string) (string, openapispec.Extensions) {
+		return getDefinitionName(namer, name)
+	}
+
+	if cmd.OpenAPIConfig == nil {
+		cmd.OpenAPIConfig = genericapiserver.DefaultOpenAPIConfig(generatedopenapi.GetOpenAPIDefinitions, namer)
+		cmd.OpenAPIConfig.GetDefinitionName = resolveDefinitionName
+		cmd.OpenAPIConfig.Info.Title = "custom-metrics-stackdriver-adapter"
+		cmd.OpenAPIConfig.Info.Version = "1.0.0"
+	}
+
+	if cmd.OpenAPIV3Config == nil {
+		cmd.OpenAPIV3Config = genericapiserver.DefaultOpenAPIV3Config(generatedopenapi.GetOpenAPIDefinitions, namer)
+		cmd.OpenAPIV3Config.GetDefinitionName = resolveDefinitionName
+		cmd.OpenAPIV3Config.Info.Title = "custom-metrics-stackdriver-adapter"
+		cmd.OpenAPIV3Config.Info.Version = "1.0.0"
 	}
 }
 

--- a/custom-metrics-stackdriver-adapter/adapter_test.go
+++ b/custom-metrics-stackdriver-adapter/adapter_test.go
@@ -22,6 +22,7 @@ import (
 
 	generatedopenapi "github.com/GoogleCloudPlatform/k8s-stackdriver/custom-metrics-stackdriver-adapter/pkg/api/generated/openapi"
 	openapinamer "k8s.io/apiserver/pkg/endpoints/openapi"
+	builder3 "k8s.io/kube-openapi/pkg/builder3"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 	customexternalmetrics "sigs.k8s.io/custom-metrics-apiserver/pkg/apiserver"
 	"sigs.k8s.io/metrics-server/pkg/api"
@@ -94,6 +95,22 @@ func TestOpenAPIDefinitionsResolution(t *testing.T) {
 		resolvedName, _ := getDefinitionName(namer, typeName)
 		if _, ok := definitions[resolvedName]; !ok {
 			t.Errorf("OpenAPI definition for GVK %v (type name %q resolved to %q) not found in generated definitions", gvk, typeName, resolvedName)
+		}
+	}
+}
+
+func TestOpenAPIV3DefinitionsResolution(t *testing.T) {
+	cmd := &StackdriverAdapter{}
+	configureOpenAPI(cmd)
+
+	names := []string{
+		"io.k8s.metrics.pkg.apis.custom_metrics.v1beta1.MetricValueList",
+		"io.k8s.metrics.pkg.apis.custom_metrics.v1beta2.MetricValueList",
+		"io.k8s.metrics.pkg.apis.external_metrics.v1beta1.ExternalMetricValueList",
+	}
+	for _, name := range names {
+		if _, err := builder3.BuildOpenAPIDefinitionsForResources(cmd.OpenAPIV3Config, name); err != nil {
+			t.Errorf("OpenAPI v3 definition for %q not found: %v", name, err)
 		}
 	}
 }


### PR DESCRIPTION
Set `OpenAPIV3Config` with the same generated definitions used for OpenAPI v2.

Observed from adapter logs with `gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.16.7-gke.0` after the API aggregation layer queried OpenAPI v3:

```text
Failed to build OpenAPI v3 for group apis/custom.metrics.k8s.io/v1beta2, "cannot find model definition for io.k8s.metrics.pkg.apis.custom_metrics.v1beta2.MetricValueList..."
Failed to build OpenAPI v3 for group apis/custom.metrics.k8s.io/v1beta1, "cannot find model definition for io.k8s.metrics.pkg.apis.custom_metrics.v1beta1.MetricValueList..."
Failed to build OpenAPI v3 for group apis/external.metrics.k8s.io/v1beta1, "cannot find model definition for io.k8s.metrics.pkg.apis.external_metrics.v1beta1.ExternalMetricValueList..."
```

Local repro: leave `OpenAPIV3Config` nil, call `cmd.Config()` before `WithCustomMetrics` / `WithExternalMetrics`, then build v3 definitions for one of the model names above. `custom-metrics-apiserver` initializes a default v3 config at that point, before metric providers are registered, so the custom/external metric definitions are missing.

#1174 added the name mapping for `OpenAPIConfig`, but `OpenAPIV3Config` is still nil. This wires v3 to the same generated definitions and adds a regression test for the exact missing model names.
