### PR TITLE
Enforce 5s timeout on all HTTP clients in kubelet-to-gcm

### DIFF
--- a/kubelet-to-gcm/monitor/config/initialize.go
+++ b/kubelet-to-gcm/monitor/config/initialize.go
@@ -104,7 +104,9 @@ func metaDataURI(resource string) string {
 
 // getGCEMetaData hits the instance's MD server.
 func getGCEMetaData(uri string) ([]byte, error) {
-	client := &http.Client{}
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+	}
 	req, err := http.NewRequest("GET", uri, nil)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create request %q for GCE metadata: %v", uri, err)

--- a/kubelet-to-gcm/monitor/controller/source.go
+++ b/kubelet-to-gcm/monitor/controller/source.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	v3 "google.golang.org/api/monitoring/v3"
 
@@ -38,7 +39,9 @@ func NewSource(cfg *monitor.SourceConfig) (*Source, error) {
 	trans := NewTranslator(cfg.Zone, cfg.Project, cfg.Cluster, cfg.Instance, cfg.Resolution)
 
 	// NewClient validates its own inputs.
-	client, err := NewClient(cfg.Host, cfg.Port, &http.Client{})
+	client, err := NewClient(cfg.Host, cfg.Port, &http.Client{
+		Timeout: 5 * time.Second,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create a controller client with config %v: %v", cfg, err)
 	}

--- a/kubelet-to-gcm/monitor/kubelet/source.go
+++ b/kubelet-to-gcm/monitor/kubelet/source.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"time"
 
 	v3 "google.golang.org/api/monitoring/v3"
 
@@ -41,7 +42,9 @@ func NewSource(cfg *monitor.SourceConfig) (*Source, error) {
 	trans := NewTranslator(cfg.Zone, cfg.Project, cfg.Cluster, cfg.ClusterLocation, cfg.Instance, cfg.InstanceID, cfg.SchemaPrefix, cfg.MonitoredResourceLabels, cfg.Resolution)
 
 	// NewClient validates its own inputs.
-	httpClient := &http.Client{}
+	httpClient := &http.Client{
+		Timeout: 5 * time.Second,
+	}
 	var err error
 	useAuthPort := false
 	if cfg.CertificateLocation != "" {
@@ -101,6 +104,7 @@ func getSecuredHttpClient(certLocation string) (*http.Client, error) {
 		return nil, fmt.Errorf("failed to parse kubelet certificate")
 	}
 	return &http.Client{
+		Timeout: 5 * time.Second,
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
 				RootCAs: certPool,


### PR DESCRIPTION
# PR Description: Enforce HTTP Client Timeouts in kubelet-to-gcm

## Summary

Enforces a 5-second timeout on `http.Client` instances in `kubelet-to-gcm` to ensure requests finish within a predictable window and prevent potential goroutine build-up during slow backend responses.

## Context

Currently, the `http.Client` defaults to an unbounded wait. This change adds a 5-second timeout to ensure that monitoring iterations remain isolated and do not accumulate if the Kubelet or GCE Metadata server is slow to respond.

## Changes

- **monitor/config/initialize.go**: Added `Timeout: 5 * time.Second` to the `http.Client` used for GCE metadata retrieval.
- **monitor/kubelet/source.go**:
  - Added `Timeout: 5 * time.Second` to standard and secured Kubelet HTTP clients.
  - Added missing `time` package import.
- **monitor/controller/source.go**:
  - Added `Timeout: 5 * time.Second` to the Controller HTTP client.
  - Added missing `time` package import.

## Verification

- Verified that all components compile successfully.
- Ran `go test ./monitor/kubelet/...` and confirmed that existing translation logic remains sound.
- All requests are now guaranteed to fail-fast within 5 seconds, which is safely below the 10-second polling interval.
