### PR TITLE
Prevent http.DefaultServeMux exposure on CMSA

### DIFF
--- a/custom-metrics-stackdriver-adapter/adapter.go
+++ b/custom-metrics-stackdriver-adapter/adapter.go
@@ -291,8 +291,9 @@ func getDefinitionName(namer *openapinamer.DefinitionNamer, name string) (string
 }
 
 func runPrometheusMetricsServer(addr string) {
-	http.Handle("/metrics", promhttp.Handler())
-	err := http.ListenAndServe(addr, nil)
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+	err := http.ListenAndServe(addr, mux)
 	klog.Fatalf("Failed server: %s", err)
 }
 


### PR DESCRIPTION
When the Prometheus /metrics endpoint is enabled, the HTTP server was initialized via `http.ListenAndServe(addr, nil)`, defaulting to the global `http.DefaultServeMux`

Transitive third-party dependencies (like k8s libraries) register global debug and profiling handlers (`/debug/pprof/*`), these  endpoints were unintentionally exposed publicly on the metrics port.

So, we're isolating the `/metrics` endpoint by initializing a dedicated `ServeMux`.

Tested on a live cluster with `--metrics-address=0.0.0.0:8080` flag configured on the CMSA deployment:

Metrics scraping still works:

```
curl -i http://localhost:8080/metrics
HTTP/1.1 200 OK
```

Profiling endpoints are no longer exposed as a side effect:

```
curl -i http://localhost:8080/debug/pprof/
HTTP/1.1 404 Not Found 
```