### PR TITLE
Cleanup verbose logging in kubelet monitor

### DIFF
--- a/kubelet-to-gcm/monitor/kubelet/source.go
+++ b/kubelet-to-gcm/monitor/kubelet/source.go
@@ -77,7 +77,7 @@ func (s *Source) GetTimeSeriesReq() (*v3.CreateTimeSeriesRequest, error) {
 	// Translate kubelet's data to GCM v3's format.
 	tsReq, err := s.translator.Translate(summary)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to translate data from summary %v: %v", summary, err)
+		return nil, fmt.Errorf("Failed to translate data from summary: %v", err)
 	}
 
 	return tsReq, nil

--- a/kubelet-to-gcm/monitor/kubelet/translate.go
+++ b/kubelet-to-gcm/monitor/kubelet/translate.go
@@ -433,7 +433,7 @@ func translateCPU(cpu *stats.CPUStats, tsFactory *timeSeriesFactory, startTime t
 		return nil, fmt.Errorf("CPU information missing.")
 	}
 	if cpu.UsageCoreNanoSeconds == nil {
-		return nil, fmt.Errorf("UsageCoreNanoSeconds missing from CPUStats %v", cpu)
+		return nil, fmt.Errorf("UsageCoreNanoSeconds missing from CPUStats")
 	}
 	// Only send cpu usage metric if start time is before current time. Right after container is started, kubelet can return start time == end time.
 	if !cpu.Time.Time.After(startTime) {
@@ -491,7 +491,7 @@ func translateFS(volume string, fs *stats.FsStats, tsFactory *timeSeriesFactory,
 	}
 	if diskTotalMD != nil {
 		if fs.CapacityBytes == nil {
-			return nil, fmt.Errorf("CapacityBytes is missing from FsStats %v", fs)
+			return nil, fmt.Errorf("CapacityBytes is missing from FsStats")
 		}
 		// Total disk available.
 		diskTotalPoint := tsFactory.newPoint(&v3.TypedValue{
@@ -503,7 +503,7 @@ func translateFS(volume string, fs *stats.FsStats, tsFactory *timeSeriesFactory,
 
 	if diskUsedMD != nil {
 		if fs.UsedBytes == nil {
-			return nil, fmt.Errorf("UsedBytes is missing from FsStats %v", fs)
+			return nil, fmt.Errorf("UsedBytes is missing from FsStats")
 		}
 		// Total disk used.
 		diskUsedPoint := tsFactory.newPoint(&v3.TypedValue{
@@ -545,7 +545,7 @@ func translateMemory(memory *stats.MemoryStats, tsFactory *timeSeriesFactory, st
 
 	if memUsedMD != nil {
 		if memory.WorkingSetBytes == nil {
-			return nil, fmt.Errorf("WorkingSetBytes information missing in MemoryStats %v", memory)
+			return nil, fmt.Errorf("WorkingSetBytes information missing in MemoryStats")
 		}
 		// Non-evictable memory.
 		nonEvictMemPoint := tsFactory.newPoint(&v3.TypedValue{


### PR DESCRIPTION
# PR Description: Cleanup Verbose and Sensitive Logging in Kubelet Monitor

## Summary

This PR refactors the error logging in the `kubelet` package to improve log hygiene and readability.

Previously, translation failures would result in printing large, complex internal data structures (such as the full `stats.Summary` object). This led to significant log bloat and made it difficult for operators to parse actual error messages.

## Changes

- **kubelet/source.go**: Removed verbose data payloads from error messages.
- **kubelet/translate.go**: Cleaned up internal `fmt.Errorf` calls to ensure log messages remain concise and actionable.

## Verification Results

- Ran `go test ./kubelet/...` in the `monitor` directory.
- All tests passed: `ok github.com/GoogleCloudPlatform/k8s-stackdriver/kubelet-to-gcm/monitor/kubelet 0.029s`
