### PR TITLE
custom-metrics-stackdriver-adapter: initialize OpenAPIV3Config for core metrics

### DIFF
--- a/custom-metrics-stackdriver-adapter/adapter.go
+++ b/custom-metrics-stackdriver-adapter/adapter.go
@@ -200,6 +200,16 @@ func main() {
 		cmd.OpenAPIConfig.Info.Version = "1.0.0"
 	}
 
+	if cmd.OpenAPIV3Config == nil {
+		namer := openapinamer.NewDefinitionNamer(api.Scheme, customexternalmetrics.Scheme)
+		cmd.OpenAPIV3Config = genericapiserver.DefaultOpenAPIV3Config(generatedopenapi.GetOpenAPIDefinitions, namer)
+		cmd.OpenAPIV3Config.GetDefinitionName = func(name string) (string, openapispec.Extensions) {
+			return getDefinitionName(namer, name)
+		}
+		cmd.OpenAPIV3Config.Info.Title = "custom-metrics-stackdriver-adapter"
+		cmd.OpenAPIV3Config.Info.Version = "1.0.0"
+	}
+
 	flags := cmd.Flags()
 	klog.InitFlags(flag.CommandLine)
 	flags.AddGoFlagSet(flag.CommandLine)


### PR DESCRIPTION
Currently, if `--enable-core-metrics-api` is set to true, the custom metrics stackdriver adapter fails to run and prints this error:
```
unable to install resource metrics API: unable to get openapi models: cannot find model definition for k8s.io/metrics/pkg/apis/metrics/v1beta1.NodeMetrics. If you added a new type, you may need to add +k8s:openapi-gen=true to the package or type and run code-gen again
```

Here, we propose initializing `cmd.OpenAPIV3Config` in `adapter.go` in the same way as `cmd.OpenAPIConfig`. This provides the OpenAPI V3 schemas (specifically for `NodeMetrics`/`PodMetrics` in the `metrics.k8s.io` API group) during API installation, preventing the V3 OpenAPI generation failure.