### PR TITLE
custom-metrics-stackdriver-adapter: use metadata informer for pod resource metrics

### DIFF
--- a/custom-metrics-stackdriver-adapter/adapter.go
+++ b/custom-metrics-stackdriver-adapter/adapter.go
@@ -36,10 +36,13 @@ import (
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	openapispec "k8s.io/kube-openapi/pkg/validation/spec"
 	coreclient "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/metadata"
+	"k8s.io/client-go/metadata/metadatainformer"
 	customexternalmetrics "sigs.k8s.io/custom-metrics-apiserver/pkg/apiserver"
 	"sigs.k8s.io/custom-metrics-apiserver/pkg/provider"
 
 	"k8s.io/apimachinery/pkg/labels"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/component-base/logs"
 	"k8s.io/klog"
@@ -52,6 +55,7 @@ import (
 )
 
 const (
+	defaultResync = 0
 	defaultExternalMetricsCacheSize = 300
 	// This is only metric info and likely to be much smaller than separate metrics of each kind above
 	defaultMetricKindCacheSize = 25
@@ -167,15 +171,28 @@ func (sa *StackdriverAdapter) withCoreMetrics(translator *translator.Translator)
 		return err
 	}
 
-	podInformer, nil := informers.ForResource(corev1.SchemeGroupVersion.WithResource("pods"))
+	config, err := sa.ClientConfig()
 	if err != nil {
 		return err
 	}
+	metadataClient, err := metadata.NewForConfig(config)
+	if err != nil {
+		return err
+	}
+	metadataInformers := metadatainformer.NewFilteredSharedInformerFactory(metadataClient, defaultResync, corev1.NamespaceAll, func(options *metav1.ListOptions) {
+		options.FieldSelector = "status.phase=Running"
+	})
+	podInformer := metadataInformers.ForResource(corev1.SchemeGroupVersion.WithResource("pods"))
 
 	nodes := informers.Core().V1().Nodes()
 	if err := api.Install(provider, podInformer.Lister(), nodes.Lister(), server.GenericAPIServer, []labels.Requirement{}); err != nil {
 		return err
 	}
+
+	server.GenericAPIServer.AddPostStartHookOrDie("custom-metrics-stackdriver-adapter-metadata-informer", func(context genericapiserver.PostStartHookContext) error {
+		metadataInformers.Start(context.Done())
+		return nil
+	})
 
 	return nil
 }


### PR DESCRIPTION
Updates `withCoreMetrics` in `adapter.go` to construct a metadata-only pod informer using `metadatainformer.NewFilteredSharedInformerFactory`.
- Defines a `defaultResync = 0` constant (matching `metrics-server`).
- Adds a `status.phase=Running` field selector filter to only track actively running pods.
- Ensures that `podInformer.Lister()` yields `*metav1.PartialObjectMetadata` objects, matching the library type expectations and preventing the interface conversion panic.

Source in metrics-server: https://github.com/kubernetes-sigs/metrics-server/blob/release-0.8/pkg/server/informer.go#L44-L52