### PR TITLE
custom-metrics-stackdriver-adapter: prevent filter injection in single-value In/NotIn selectors

### DIFF
--- a/custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder.go
+++ b/custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder.go
@@ -741,7 +741,7 @@ func (t *Translator) filterForSelector(metricSelector labels.Selector, allowedLa
 		case selection.In:
 			if isAllowedLabelName(req.Key(), allowedLabelPrefixes, allowedFullLabelNames) {
 				if len(l) == 1 {
-					filters = append(filters, fmt.Sprintf("%s = %s", req.Key(), l[0]))
+					filters = append(filters, fmt.Sprintf("%s = %q", req.Key(), l[0]))
 				} else {
 					filters = append(filters, fmt.Sprintf("%s = one_of(%s)", req.Key(), strings.Join(quoteAll(l), ",")))
 				}
@@ -751,7 +751,7 @@ func (t *Translator) filterForSelector(metricSelector labels.Selector, allowedLa
 		case selection.NotIn:
 			if isAllowedLabelName(req.Key(), allowedLabelPrefixes, allowedFullLabelNames) {
 				if len(l) == 1 {
-					filters = append(filters, fmt.Sprintf("%s != %s", req.Key(), l[0]))
+					filters = append(filters, fmt.Sprintf("%s != %q", req.Key(), l[0]))
 				} else {
 					filters = append(filters, fmt.Sprintf("NOT %s = one_of(%s)", req.Key(), strings.Join(quoteAll(l), ",")))
 				}

--- a/custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go
+++ b/custom-metrics-stackdriver-adapter/pkg/adapter/translator/query_builder_test.go
@@ -991,6 +991,29 @@ func TestTranslator_GetExternalMetricRequest_DifferentProject(t *testing.T) {
 	}
 }
 
+func TestTranslator_GetExternalMetricRequest_SingleInAndNotIn(t *testing.T) {
+	translator, sdService := newFakeTranslatorForExternalMetrics(2*time.Minute, time.Minute, "my-project", time.Date(2017, 1, 2, 13, 2, 0, 0, time.UTC))
+	req1, _ := labels.NewRequirement("resource.type", selection.Equals, []string{"k8s_pod"})
+	req2, _ := labels.NewRequirement("resource.labels.namespace_name", selection.In, []string{"default"})
+	req3, _ := labels.NewRequirement("resource.labels.pod_name", selection.NotIn, []string{"kube-system"})
+	request, err := translator.GetExternalMetricRequest("custom.googleapis.com/my/metric/name", "CUMULATIVE", "INT64", labels.NewSelector().Add(*req1, *req2, *req3))
+	if err != nil {
+		t.Fatalf("Translation error: %s", err)
+	}
+	expectedRequest := sdService.Projects.TimeSeries.List("projects/my-project").
+		Filter("metric.type = \"custom.googleapis.com/my/metric/name\" " +
+			"AND resource.labels.namespace_name = \"default\" " +
+			"AND resource.labels.pod_name != \"kube-system\" " +
+			"AND resource.type = \"k8s_pod\"").
+		IntervalStartTime("2017-01-02T13:00:00Z").
+		IntervalEndTime("2017-01-02T13:02:00Z").
+		AggregationPerSeriesAligner("ALIGN_RATE").
+		AggregationAlignmentPeriod("60s")
+	if !reflect.DeepEqual(*request, *expectedRequest) {
+		t.Errorf("Unexpected result. Expected \n%v,\n received: \n%v", *expectedRequest, *request)
+	}
+}
+
 func TestTranslator_GetExternalMetricRequest_InvalidLabel(t *testing.T) {
 	translator, _ := newFakeTranslatorForExternalMetrics(2*time.Minute, time.Minute, "my-project", time.Date(2017, 1, 2, 13, 2, 0, 0, time.UTC))
 	_, err := translator.GetExternalMetricRequest("custom.googleapis.com/my/metric/name", "GAUGE", "INT64", labels.SelectorFromSet(labels.Set{


### PR DESCRIPTION
## Description
This PR resolves a security vulnerability where users with permissions to query external metrics could bypass label constraints and execute arbitrary Stackdriver filter queries. 

### The Issue
In `pkg/adapter/translator/query_builder.go`, the `filterForSelector` function processes the external metric `labelSelector`. For optimization, if a selector uses the `In` or `NotIn` operators with **exactly one value**, the code translated them into standard equality (`=`) or inequality (`!=`) checks.

However, the single item was templated directly into the query string using `%s` **without any quoting or escaping**:
```go
// Vulnerable Code:
filters = append(filters, fmt.Sprintf("%s = %s", req.Key(), l[0]))
```

If a malicious user supplied a crafted label value containing double quotes and operators (e.g., `my-value" OR metric.type = "some-other-metric"`), they could escape the string boundary and inject arbitrary query logic, leading to unauthorized metric data exfiltration.

### The Fix
This PR enforces strict double-quoting and escaping for all comparison filter values, regardless of the list size, by replacing the vulnerable raw `%s` templates with `%q` (which uses `strconv.Quote` under the hood):
```go
// Remediated Code:
filters = append(filters, fmt.Sprintf("%s = %q", req.Key(), l[0]))
```

This safely escapes any embedded quote characters, ensuring they are treated as single string literals by the Stackdriver filter parser.

---

## Changes
* **`pkg/adapter/translator/query_builder.go`**: Updated `selection.In` and `selection.NotIn` single-item branches to format using `%q` instead of `%s`.
* **`pkg/adapter/translator/query_builder_test.go`**: Added `TestTranslator_GetExternalMetricRequest_SingleInAndNotIn` to verify that single-value `In` and `NotIn` selector requirements are correctly quoted in the generated Stackdriver filter queries.

## Verification Results
* All 180+ custom-metrics-stackdriver-adapter unit tests compiled and passed successfully:
  ```bash
  $ make test
  ok      github.com/GoogleCloudPlatform/k8s-stackdriver/custom-metrics-stackdriver-adapter/pkg/adapter/translator        4.254s
  ```

