### PR TITLE
Fix error handling in getMetricDescriptors

### DIFF
--- a/prometheus-to-sd/translator/stackdriver.go
+++ b/prometheus-to-sd/translator/stackdriver.go
@@ -97,7 +97,7 @@ func getMetricDescriptors(ctx context.Context, client *monitoring.MetricClient, 
 		}
 		if err != nil {
 			glog.Warningf("Error while fetching metric descriptors for %v: %v", config.SourceConfig.Component, err)
-			return metrics, nil
+			return nil, err
 		}
 		if _, metricName, err := parseMetricType(config, metricDescriptor.Type); err == nil {
 			metrics[metricName] = metricDescriptor


### PR DESCRIPTION
getMetricDescriptors was returning a nil error even when it failed to fetch metric descriptors due to an API error. This caused the cache manager to overwrite the descriptor cache with partial or empty data, silencing metric exports.

This change ensures that the actual error is returned so that the cache manager can retain the previous cache.