### PR TITLE
Fix: Allow /etc/srv/kubernetes/ and /etc/srv/ paths in token validation

### DIFF
--- a/prometheus-to-sd/config/common_config.go
+++ b/prometheus-to-sd/config/common_config.go
@@ -138,7 +138,7 @@ func isValidTokenFile(path string) bool {
 		return false
 	}
 	cleaned := filepath.Clean(path)
-	for _, prefix := range []string{"/var/run/secrets/", "/etc/secrets/", "/etc/prometheus/"} {
+	for _, prefix := range []string{"/var/run/secrets/", "/etc/secrets/", "/etc/prometheus/", "/etc/srv/kubernetes/", "/etc/srv/"} {
 		if strings.HasPrefix(cleaned, prefix) {
 			return true
 		}

--- a/prometheus-to-sd/config/common_config_test.go
+++ b/prometheus-to-sd/config/common_config_test.go
@@ -32,6 +32,7 @@ func TestIsValidTokenFile(t *testing.T) {
 		{"/var/run/secrets/sub/token", true},
 		{"/etc/secrets/my-token", true},
 		{"/etc/prometheus/token", true},
+		{"/etc/srv/kubernetes/my-token", true},
 		{"/etc/passwd", false},
 		{"/var/run/secrets/../../etc/passwd", false},
 		{"relative/path", false},


### PR DESCRIPTION
# Description
This PR updates the token path validation in prometheus-to-sd to allowlist /etc/srv/kubernetes/ and /etc/srv/ as valid prefixes for token files.

# Context
Recent security hardening introduced strict path validation for token files. However, some Kubernetes deployments and environments mount service account tokens or credential files under /etc/srv/kubernetes/ (or more generally /etc/srv/). Without these paths in the allowlist, prometheus-to-sd fails to authenticate in these environments.

This change restores compatibility for these deployments while maintaining the security benefits of path validation against other unauthorized paths.

# Changes
prometheus-to-sd/config/common_config.go: Added /etc/srv/kubernetes/ and /etc/srv/ to the allowed prefixes in isValidTokenFile.
prometheus-to-sd/config/common_config_test.go: Added a unit test case to verify that a token path under /etc/srv/kubernetes/ is successfully validated.
# Testing
Ran unit tests in the config package:

bash


go test -v ./config/...
All tests passed, including the new test case.