### PR TITLE
Sanitize Stackdriver API error responses to prevent SA email disclosu…

### DIFF
--- a/custom-metrics-stackdriver-adapter/pkg/adapter/translator/errors.go
+++ b/custom-metrics-stackdriver-adapter/pkg/adapter/translator/errors.go
@@ -23,12 +23,14 @@ import (
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog"
 )
 
 // NewNoSuchMetricError returns a StatusError indicating that the given metric could not be found.
 // It is similar to NewNotFound, but more specialized.
 func NewNoSuchMetricError(metricName string, err error) *apierr.StatusError {
-	return newMetricNotFoundWithMessageError(fmt.Sprintf("the server could not find the descriptor for metric %s: %s", metricName, err))
+	klog.V(4).Infof("failed to get descriptor for metric %s: %v", metricName, err)
+	return newMetricNotFoundWithMessageError(fmt.Sprintf("the server could not find the descriptor for metric %s", metricName))
 }
 
 // NewMetricNotFoundError returns a StatusError indicating that the given metric could not be found.

--- a/custom-metrics-stackdriver-adapter/pkg/adapter/translator/errors_test.go
+++ b/custom-metrics-stackdriver-adapter/pkg/adapter/translator/errors_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package translator
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestNewNoSuchMetricError_SanitizesSensitiveError(t *testing.T) {
+	metricName := "custom.googleapis.com/test_metric"
+	sensitiveErr := errors.New("googleapi: Error 403: Permission google.navigation... denied, service account test-sa@my-gcp-project.iam.gserviceaccount.com does not have permission")
+
+	statusErr := NewNoSuchMetricError(metricName, sensitiveErr)
+
+	if statusErr == nil {
+		t.Fatalf("expected non-nil StatusError")
+	}
+
+	if statusErr.ErrStatus.Code != http.StatusNotFound {
+		t.Errorf("expected status code %d, got %d", http.StatusNotFound, statusErr.ErrStatus.Code)
+	}
+
+	if strings.Contains(statusErr.ErrStatus.Message, "test-sa@my-gcp-project.iam.gserviceaccount.com") {
+		t.Errorf("status message leaks sensitive service account details: %s", statusErr.ErrStatus.Message)
+	}
+}


### PR DESCRIPTION
Prevent raw underlying Stackdriver API error details from being formatted directly into client-facing StatusError messages when looking up metric descriptors.

Previously, errors returned by the Stackdriver API (such as 403 Forbidden responses when querying inaccessible projects) were formatted directly into the HTTP response body returned to API callers, potentially exposing underlying GCP Service Account email identities.

This change logs the detailed error internally via klog for server-side debugging while returning a generic metric-not-found StatusError message to the client. Unit tests are also added to verify error sanitization.
