### PR TITLE
Sanitize metric and resource names in error responses

### DIFF
--- a/custom-metrics-stackdriver-adapter/pkg/adapter/translator/errors.go
+++ b/custom-metrics-stackdriver-adapter/pkg/adapter/translator/errors.go
@@ -29,26 +29,26 @@ import (
 // NewNoSuchMetricError returns a StatusError indicating that the given metric could not be found.
 // It is similar to NewNotFound, but more specialized.
 func NewNoSuchMetricError(metricName string, err error) *apierr.StatusError {
-	klog.V(4).Infof("failed to get descriptor for metric %s: %v", metricName, err)
-	return newMetricNotFoundWithMessageError(fmt.Sprintf("the server could not find the descriptor for metric %s", metricName))
+	klog.V(4).Infof("failed to get descriptor for metric %q: %v", metricName, err)
+	return newMetricNotFoundWithMessageError(fmt.Sprintf("the server could not find the descriptor for metric %q", metricName))
 }
 
 // NewMetricNotFoundError returns a StatusError indicating that the given metric could not be found.
 // It is similar to NewNotFound, but more specialized.
 func NewMetricNotFoundError(resource schema.GroupResource, metricName string) *apierr.StatusError {
-	return newMetricNotFoundWithMessageError(fmt.Sprintf("the server could not find the metric %s for %s", metricName, resource.String()))
+	return newMetricNotFoundWithMessageError(fmt.Sprintf("the server could not find the metric %q for %s", metricName, resource.String()))
 }
 
 // NewMetricNotFoundForError returns a StatusError indicating that the given metric could not be
 // found for the given named object. It is similar to NewNotFound, but more specialized.
 func NewMetricNotFoundForError(resource schema.GroupResource, metricName string, resourceName string) *apierr.StatusError {
-	return newMetricNotFoundWithMessageError(fmt.Sprintf("the server could not find the metric %s for %s %s", metricName, resource.String(), resourceName))
+	return newMetricNotFoundWithMessageError(fmt.Sprintf("the server could not find the metric %q for %s %q", metricName, resource.String(), resourceName))
 }
 
 // NewExternalMetricNotFoundError returns a status error indicating that the given metric could
 // not be found. It is similar to NewNotFound, but more specialized.
 func NewExternalMetricNotFoundError(metricName string) *apierr.StatusError {
-	return newMetricNotFoundWithMessageError(fmt.Sprintf("the server could not find the metric %s for provided labels", metricName))
+	return newMetricNotFoundWithMessageError(fmt.Sprintf("the server could not find the metric %q for provided labels", metricName))
 }
 
 // NewLabelNotAllowedError returns a status error indicating that the given label is forbidden.

--- a/custom-metrics-stackdriver-adapter/pkg/adapter/translator/errors_test.go
+++ b/custom-metrics-stackdriver-adapter/pkg/adapter/translator/errors_test.go
@@ -18,9 +18,13 @@ package translator
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 	"testing"
+
+	apierr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func TestNewNoSuchMetricError_SanitizesSensitiveError(t *testing.T) {
@@ -39,5 +43,61 @@ func TestNewNoSuchMetricError_SanitizesSensitiveError(t *testing.T) {
 
 	if strings.Contains(statusErr.ErrStatus.Message, "test-sa@my-gcp-project.iam.gserviceaccount.com") {
 		t.Errorf("status message leaks sensitive service account details: %s", statusErr.ErrStatus.Message)
+	}
+}
+
+func TestMetricErrors_QuotesMetricNames(t *testing.T) {
+	metricName := "<script>alert('xss')</script>"
+	resourceName := "<img src=x onerror=alert(1)>"
+	gr := schema.GroupResource{Group: "apps", Resource: "deployments"}
+
+	quotedMetricName := fmt.Sprintf("%q", metricName)
+	quotedResourceName := fmt.Sprintf("%q", resourceName)
+
+	testCases := []struct {
+		name              string
+		err               *apierr.StatusError
+		expectedSubstring string
+	}{
+		{
+			name:              "NewNoSuchMetricError",
+			err:               NewNoSuchMetricError(metricName, errors.New("not found")),
+			expectedSubstring: quotedMetricName,
+		},
+		{
+			name:              "NewMetricNotFoundError",
+			err:               NewMetricNotFoundError(gr, metricName),
+			expectedSubstring: quotedMetricName,
+		},
+		{
+			name:              "NewMetricNotFoundForError",
+			err:               NewMetricNotFoundForError(gr, metricName, resourceName),
+			expectedSubstring: quotedMetricName,
+		},
+		{
+			name:              "NewExternalMetricNotFoundError",
+			err:               NewExternalMetricNotFoundError(metricName),
+			expectedSubstring: quotedMetricName,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.err == nil {
+				t.Fatalf("expected non-nil StatusError")
+			}
+			if tc.err.ErrStatus.Code != http.StatusNotFound {
+				t.Errorf("expected status code %d, got %d", http.StatusNotFound, tc.err.ErrStatus.Code)
+			}
+			if !strings.Contains(tc.err.ErrStatus.Message, tc.expectedSubstring) {
+				t.Errorf("expected status message to contain quoted string %s, got %q", tc.expectedSubstring, tc.err.ErrStatus.Message)
+			}
+		})
+	}
+
+	// Also verify resourceName is quoted in NewMetricNotFoundForError
+	errWithResource := NewMetricNotFoundForError(gr, metricName, resourceName)
+	if !strings.Contains(errWithResource.ErrStatus.Message, quotedResourceName) {
+		t.Errorf("expected status message to contain quoted resource name %s, got %q", quotedResourceName, errWithResource.ErrStatus.Message)
 	}
 }


### PR DESCRIPTION
Escape metricName and resourceName using %q format specifiers in error messages within pkg/adapter/translator/errors.go to prevent Reflected Cross-Site Scripting (XSS). Add unit tests in errors_test.go verifying that metric and resource names containing script/HTML tags are safely quoted in status error messages.