### PR TITLE
Update go version and bump version tag

### DIFF
--- a/custom-metrics-stackdriver-adapter/Dockerfile
+++ b/custom-metrics-stackdriver-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.26.2-alpine as builder
+FROM golang:1.26.7-alpine AS builder
 WORKDIR ${GOPATH}/src/github.com/GoogleCloudPlatform/k8s-stackdriver/custom-metrics-stackdriver-adapter
 COPY . ./
 RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -o /adapter

--- a/custom-metrics-stackdriver-adapter/Makefile
+++ b/custom-metrics-stackdriver-adapter/Makefile
@@ -3,7 +3,7 @@ GOOS?=linux
 OUT_DIR?=build
 PACKAGE=github.com/GoogleCloudPlatform/k8s-stackdriver/custom-metrics-stackdriver-adapter
 PREFIX?=staging-k8s.gcr.io
-TAG ?= v0.16.9
+TAG ?= v0.16.10
 PKG := $(shell find pkg/* -type f)
 
 .PHONY: build docker push test clean verify-generated update-generated

--- a/custom-metrics-stackdriver-adapter/go.mod
+++ b/custom-metrics-stackdriver-adapter/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/k8s-stackdriver/custom-metrics-stackdriver-adapter
 
-go 1.26.2
+go 1.26.7
 
 require (
 	cloud.google.com/go/compute/metadata v0.9.0


### PR DESCRIPTION
Update the go version to 1.26.7 to fix CVEs in previous versions (e.g. CVE-2026-39821).