### PR TITLE
Update custom-metrics-stackdriver-adapter image to v0.16.10-gke.0

### DIFF
--- a/custom-metrics-stackdriver-adapter/deploy/production/adapter.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/production/adapter.yaml
@@ -81,7 +81,7 @@ spec:
         value: "present"
         effect: "NoSchedule"
       containers:
-      - image: gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.16.9-gke.0
+      - image: gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.16.10-gke.0
         imagePullPolicy: Always
         name: pod-custom-metrics-stackdriver-adapter
         command:

--- a/custom-metrics-stackdriver-adapter/deploy/production/adapter_new_resource_model.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/production/adapter_new_resource_model.yaml
@@ -97,7 +97,7 @@ spec:
         value: "present"
         effect: "NoSchedule"
       containers:
-      - image: gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.16.9-gke.0
+      - image: gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.16.10-gke.0
         imagePullPolicy: Always
         name: pod-custom-metrics-stackdriver-adapter
         command:

--- a/custom-metrics-stackdriver-adapter/deploy/staging/adapter_new_resource_model.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/staging/adapter_new_resource_model.yaml
@@ -101,7 +101,7 @@ spec:
         value: "present"
         effect: "NoSchedule"
       containers:
-      - image: gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.16.9-gke.0
+      - image: gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.16.10-gke.0
         imagePullPolicy: Always
         name: pod-custom-metrics-stackdriver-adapter
         command:

--- a/custom-metrics-stackdriver-adapter/deploy/staging/adapter_new_resource_model_external_cache.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/staging/adapter_new_resource_model_external_cache.yaml
@@ -92,7 +92,7 @@ spec:
     spec:
       serviceAccountName: custom-metrics-stackdriver-adapter
       containers:
-        - image: gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.16.9-gke.0
+        - image: gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.16.10-gke.0
           imagePullPolicy: Always
           name: pod-custom-metrics-stackdriver-adapter
           command:

--- a/custom-metrics-stackdriver-adapter/deploy/staging/adapter_old_resource_model.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/staging/adapter_old_resource_model.yaml
@@ -85,7 +85,7 @@ spec:
         value: "present"
         effect: "NoSchedule"
       containers:
-      - image: gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.16.9-gke.0
+      - image: gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.16.10-gke.0
         imagePullPolicy: Always
         name: pod-custom-metrics-stackdriver-adapter
         command:

--- a/custom-metrics-stackdriver-adapter/deploy/test/adapter_new_resource_model_with_core_metrics.yaml
+++ b/custom-metrics-stackdriver-adapter/deploy/test/adapter_new_resource_model_with_core_metrics.yaml
@@ -101,7 +101,7 @@ spec:
         value: "present"
         effect: "NoSchedule"
       containers:
-      - image: gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.16.9-gke.0
+      - image: gcr.io/gke-release/custom-metrics-stackdriver-adapter:v0.16.10-gke.0
         imagePullPolicy: Always
         name: pod-custom-metrics-stackdriver-adapter
         command:


### PR DESCRIPTION
Update k8s resources to reference newly released version.

This commit updates the image for the custom-metrics-stackdriver-adapter to version v0.16.10-gke.0 in the following deployment files:

deploy/production/adapter.yaml
deploy/production/adapter_new_resource_model.yaml
deploy/staging/adapter_new_resource_model.yaml
deploy/staging/adapter_new_resource_model_external_cache.yaml
deploy/staging/adapter_old_resource_model.yaml
deploy/test/adapter_new_resource_model_with_core_metrics.yaml