### PR TITLE
[PATCH] Revert "Restrict API endpoint overrides to trusted Google domains"

### DIFF
--- a/prometheus-to-sd/main.go
+++ b/prometheus-to-sd/main.go
@@ -293,10 +293,6 @@ func getEndpoint(input string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("Failed to parse api override: %v", err)
 	}
-	hostname := u.Hostname()
-	if hostname != "googleapis.com" && !strings.HasSuffix(hostname, ".googleapis.com") {
-		return "", fmt.Errorf("untrusted endpoint %q: must be a googleapis.com domain", hostname)
-	}
 	port := u.Port()
 	if port == "" {
 		switch u.Scheme {

--- a/prometheus-to-sd/main_test.go
+++ b/prometheus-to-sd/main_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetEndpointTrusted(t *testing.T) {
+func TestGetEndpoint(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected string
@@ -31,6 +31,11 @@ func TestGetEndpointTrusted(t *testing.T) {
 		{"monitoring.googleapis.com:443", "monitoring.googleapis.com:443"},
 		{"https://monitoring.googleapis.com", "monitoring.googleapis.com:443"},
 		{"http://test-monitoring.sandbox.googleapis.com:80", "test-monitoring.sandbox.googleapis.com:80"},
+		{"https://monitoring.apis-tpczero.goog/", "monitoring.apis-tpczero.goog:443"},
+		{"monitoring.apis-tpczero.goog", "monitoring.apis-tpczero.goog:443"},
+ 		{"http://test-monitoring.sandbox.googleapis.com:80", "test-monitoring.sandbox.googleapis.com:80"},
+		{"http://127.0.0.1:8080", "127.0.0.1:8080"},
+		{"localhost:8080", "localhost:8080"},
 		{"googleapis.com", "googleapis.com:443"},
 	}
 
@@ -39,21 +44,5 @@ func TestGetEndpointTrusted(t *testing.T) {
 		if assert.NoError(t, err, "input: %s", tc.input) {
 			assert.Equal(t, tc.expected, res, "input: %s", tc.input)
 		}
-	}
-}
-
-func TestGetEndpointUntrusted(t *testing.T) {
-	tests := []string{
-		"attacker.com",
-		"https://attacker.com",
-		"monitoring.googleapis.com.attacker.com",
-		"https://attacker.com/?foo=.googleapis.com",
-		"http://127.0.0.1:8080",
-	}
-
-	for _, tc := range tests {
-		_, err := getEndpoint(tc)
-		assert.Error(t, err, "input: %s", tc)
-		assert.Contains(t, err.Error(), "untrusted endpoint")
 	}
 }


### PR DESCRIPTION
This reverts commit 7e24006c6014608bf5882f9283e1123cd6058149.

Reason for revert:
The endpoint restriction blocks other Google Cloud environments such as TPC (Trusted Partner Cloud) which use universe domains like *.apis-tpczero.goog, causing prometheus-to-sd to fail initialization with "untrusted endpoint: must be a googleapis.com domain".

AIP-166 universe domain authentication and validation is enforced by the Google Cloud client libraries and credentials (ADC). Setting --api-override is an operator/manifest configuration and does not cross a trust boundary.